### PR TITLE
Vc: update to Vc 0.7.4

### DIFF
--- a/math/vc/include/Vc/avx/debug.h
+++ b/math/vc/include/Vc/avx/debug.h
@@ -45,7 +45,7 @@ class DebugStream
     private:
         template<typename T, typename V> static void printVector(V _x)
         {
-            enum { Size = sizeof(V) / sizeof(T) };
+            enum JustSomeName__ { Size = sizeof(V) / sizeof(T) };
             union { V v; T m[Size]; } x = { _x };
             std::cerr << '[' << std::setprecision(24) << x.m[0];
             for (int i = 1; i < Size; ++i) {

--- a/math/vc/include/Vc/avx/shuffle.h
+++ b/math/vc/include/Vc/avx/shuffle.h
@@ -114,7 +114,7 @@ namespace Vc
         static Vc_ALWAYS_INLINE m256i Vc_CONST blend(param256i x, param256i y) {
             return _mm256_castps_si256(blend<Dst0, Dst1, Dst2, Dst3, Dst4, Dst5, Dst6, Dst7>(_mm256_castsi256_ps(x), _mm256_castsi256_ps(y)));
         }
-        template<VecPos Dst> struct ScaleForBlend { enum { Value = Dst >= X4 ? Dst - X4 + Y0 : Dst }; };
+        template<VecPos Dst> struct ScaleForBlend { enum JustSomeName__ { Value = Dst >= X4 ? Dst - X4 + Y0 : Dst }; };
         template<VecPos Dst0, VecPos Dst1, VecPos Dst2, VecPos Dst3, VecPos Dst4, VecPos Dst5, VecPos Dst6, VecPos Dst7>
         static Vc_ALWAYS_INLINE m256 Vc_CONST permute(param256 x) {
             VC_STATIC_ASSERT(Dst0 >= X0 && Dst0 <= X7, Incorrect_Range);

--- a/math/vc/include/Vc/avx/types.h
+++ b/math/vc/include/Vc/avx/types.h
@@ -77,8 +77,8 @@ namespace AVX
     template<> struct SseVectorType<m128i> { typedef m128i Type; };
     template<> struct SseVectorType<m128d> { typedef m128d Type; };
 
-    template<typename T> struct HasVectorDivisionHelper { enum { Value = 1 }; };
-    //template<> struct HasVectorDivisionHelper<unsigned int> { enum { Value = 0 }; };
+    template<typename T> struct HasVectorDivisionHelper { enum JustSomeName__ { Value = 1 }; };
+    //template<> struct HasVectorDivisionHelper<unsigned int> { enum JustSomeName__ { Value = 0 }; };
 
     template<typename T> struct VectorHelperSize;
 

--- a/math/vc/include/Vc/avx/vector.tcc
+++ b/math/vc/include/Vc/avx/vector.tcc
@@ -1286,7 +1286,7 @@ template<typename VectorType, typename EntryType> struct VectorShift<32, 8, Vect
 };
 template<typename VectorType, typename EntryType> struct VectorShift<16, 8, VectorType, EntryType>
 {
-    enum {
+    enum JustSomeName__ {
         EntryTypeSizeof = sizeof(EntryType)
     };
     static Vc_INTRINSIC VectorType shifted(VC_ALIGNED_PARAMETER(VectorType) v, int amount)
@@ -1319,7 +1319,7 @@ template<size_t SIMDWidth, size_t Size, typename VectorType, typename EntryType>
 template<typename VectorType, typename EntryType> struct VectorRotate<32, 4, VectorType, EntryType>
 {
     typedef typename SseVectorType<VectorType>::Type SmallV;
-    enum {
+    enum JustSomeName__ {
         EntryTypeSizeof = sizeof(EntryType)
     };
     static Vc_INTRINSIC VectorType rotated(VC_ALIGNED_PARAMETER(VectorType) v, int amount)
@@ -1338,7 +1338,7 @@ template<typename VectorType, typename EntryType> struct VectorRotate<32, 4, Vec
 template<typename VectorType, typename EntryType> struct VectorRotate<32, 8, VectorType, EntryType>
 {
     typedef typename SseVectorType<VectorType>::Type SmallV;
-    enum {
+    enum JustSomeName__ {
         EntryTypeSizeof = sizeof(EntryType)
     };
     static Vc_INTRINSIC VectorType rotated(VC_ALIGNED_PARAMETER(VectorType) v, int amount)
@@ -1360,7 +1360,7 @@ template<typename VectorType, typename EntryType> struct VectorRotate<32, 8, Vec
 };
 template<typename VectorType, typename EntryType> struct VectorRotate<16, 8, VectorType, EntryType>
 {
-    enum {
+    enum JustSomeName__ {
         EntryTypeSizeof = sizeof(EntryType)
     };
     static Vc_INTRINSIC VectorType rotated(VC_ALIGNED_PARAMETER(VectorType) v, int amount)

--- a/math/vc/include/Vc/common/macros.h
+++ b/math/vc/include/Vc/common/macros.h
@@ -181,22 +181,22 @@
 #endif
 
 #define unrolled_loop16(_it_, _start_, _end_, _code_) \
-if (_start_ +  0 < _end_) { enum { _it_ = (_start_ +  0) < _end_ ? (_start_ +  0) : _start_ }; _code_ } \
-if (_start_ +  1 < _end_) { enum { _it_ = (_start_ +  1) < _end_ ? (_start_ +  1) : _start_ }; _code_ } \
-if (_start_ +  2 < _end_) { enum { _it_ = (_start_ +  2) < _end_ ? (_start_ +  2) : _start_ }; _code_ } \
-if (_start_ +  3 < _end_) { enum { _it_ = (_start_ +  3) < _end_ ? (_start_ +  3) : _start_ }; _code_ } \
-if (_start_ +  4 < _end_) { enum { _it_ = (_start_ +  4) < _end_ ? (_start_ +  4) : _start_ }; _code_ } \
-if (_start_ +  5 < _end_) { enum { _it_ = (_start_ +  5) < _end_ ? (_start_ +  5) : _start_ }; _code_ } \
-if (_start_ +  6 < _end_) { enum { _it_ = (_start_ +  6) < _end_ ? (_start_ +  6) : _start_ }; _code_ } \
-if (_start_ +  7 < _end_) { enum { _it_ = (_start_ +  7) < _end_ ? (_start_ +  7) : _start_ }; _code_ } \
-if (_start_ +  8 < _end_) { enum { _it_ = (_start_ +  8) < _end_ ? (_start_ +  8) : _start_ }; _code_ } \
-if (_start_ +  9 < _end_) { enum { _it_ = (_start_ +  9) < _end_ ? (_start_ +  9) : _start_ }; _code_ } \
-if (_start_ + 10 < _end_) { enum { _it_ = (_start_ + 10) < _end_ ? (_start_ + 10) : _start_ }; _code_ } \
-if (_start_ + 11 < _end_) { enum { _it_ = (_start_ + 11) < _end_ ? (_start_ + 11) : _start_ }; _code_ } \
-if (_start_ + 12 < _end_) { enum { _it_ = (_start_ + 12) < _end_ ? (_start_ + 12) : _start_ }; _code_ } \
-if (_start_ + 13 < _end_) { enum { _it_ = (_start_ + 13) < _end_ ? (_start_ + 13) : _start_ }; _code_ } \
-if (_start_ + 14 < _end_) { enum { _it_ = (_start_ + 14) < _end_ ? (_start_ + 14) : _start_ }; _code_ } \
-if (_start_ + 15 < _end_) { enum { _it_ = (_start_ + 15) < _end_ ? (_start_ + 15) : _start_ }; _code_ } \
+if (_start_ +  0 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  0) < _end_ ? (_start_ +  0) : _start_ }; _code_ } \
+if (_start_ +  1 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  1) < _end_ ? (_start_ +  1) : _start_ }; _code_ } \
+if (_start_ +  2 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  2) < _end_ ? (_start_ +  2) : _start_ }; _code_ } \
+if (_start_ +  3 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  3) < _end_ ? (_start_ +  3) : _start_ }; _code_ } \
+if (_start_ +  4 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  4) < _end_ ? (_start_ +  4) : _start_ }; _code_ } \
+if (_start_ +  5 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  5) < _end_ ? (_start_ +  5) : _start_ }; _code_ } \
+if (_start_ +  6 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  6) < _end_ ? (_start_ +  6) : _start_ }; _code_ } \
+if (_start_ +  7 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  7) < _end_ ? (_start_ +  7) : _start_ }; _code_ } \
+if (_start_ +  8 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  8) < _end_ ? (_start_ +  8) : _start_ }; _code_ } \
+if (_start_ +  9 < _end_) { enum JustSomeName__ { _it_ = (_start_ +  9) < _end_ ? (_start_ +  9) : _start_ }; _code_ } \
+if (_start_ + 10 < _end_) { enum JustSomeName__ { _it_ = (_start_ + 10) < _end_ ? (_start_ + 10) : _start_ }; _code_ } \
+if (_start_ + 11 < _end_) { enum JustSomeName__ { _it_ = (_start_ + 11) < _end_ ? (_start_ + 11) : _start_ }; _code_ } \
+if (_start_ + 12 < _end_) { enum JustSomeName__ { _it_ = (_start_ + 12) < _end_ ? (_start_ + 12) : _start_ }; _code_ } \
+if (_start_ + 13 < _end_) { enum JustSomeName__ { _it_ = (_start_ + 13) < _end_ ? (_start_ + 13) : _start_ }; _code_ } \
+if (_start_ + 14 < _end_) { enum JustSomeName__ { _it_ = (_start_ + 14) < _end_ ? (_start_ + 14) : _start_ }; _code_ } \
+if (_start_ + 15 < _end_) { enum JustSomeName__ { _it_ = (_start_ + 15) < _end_ ? (_start_ + 15) : _start_ }; _code_ } \
 do {} while ( false )
 
 #define for_all_vector_entries(_it_, _code_) \

--- a/math/vc/include/Vc/common/operators.h
+++ b/math/vc/include/Vc/common/operators.h
@@ -6,12 +6,12 @@ namespace
 template<typename Cond, typename T> struct EnableIfNeitherIntegerNorVector : public EnableIf<!CanConvertToInt<Cond>::Value, T> {};
 template<typename Cond, typename T> struct EnableIfNeitherIntegerNorVector<Vector<Cond>, T>;
 
-template<typename T> struct IsVector             { enum { Value = false }; };
-template<typename T> struct IsVector<Vector<T> > { enum { Value =  true }; };
+template<typename T> struct IsVector             { enum JustSomeName__ { Value = false }; };
+template<typename T> struct IsVector<Vector<T> > { enum JustSomeName__ { Value =  true }; };
 
 template<typename T0, typename T1, typename V0, typename V1> struct IsTypeCombinationOf
 {
-    enum {
+    enum JustSomeName__ {
         Value = IsVector<V0>::Value ? (IsVector<V1>::Value ? ( // Vec × Vec
                     (    IsEqualType<T0, V0>::Value && HasImplicitCast<T1, V1>::Value && !HasImplicitCast<T1, int>::Value) ||
                     (HasImplicitCast<T0, V0>::Value &&     IsEqualType<T1, V1>::Value && !HasImplicitCast<T0, int>::Value) ||
@@ -32,7 +32,7 @@ template<typename T0, typename T1, typename V0, typename V1> struct IsTypeCombin
 
 template<typename T0, typename T1, typename V> struct IsVectorOperands
 {
-    enum {
+    enum JustSomeName__ {
         Value = (HasImplicitCast<T0, V>::Value && !HasImplicitCast<T0, int>::Value && !IsEqualType<T0, V>::Value && IsEqualType<T1, V>::Value)
             ||  (HasImplicitCast<T1, V>::Value && !HasImplicitCast<T1, int>::Value && !IsEqualType<T1, V>::Value && IsEqualType<T0, V>::Value)
     };

--- a/math/vc/include/Vc/common/types.h
+++ b/math/vc/include/Vc/common/types.h
@@ -74,42 +74,42 @@ namespace
     template<bool Test, typename T = void> struct EnableIf { typedef T Value; };
     template<typename T> struct EnableIf<false, T> {};
 
-    template<typename T> struct IsSignedInteger    { enum { Value = 0 }; };
-    template<> struct IsSignedInteger<signed char> { enum { Value = 1 }; };
-    template<> struct IsSignedInteger<short>       { enum { Value = 1 }; };
-    template<> struct IsSignedInteger<int>         { enum { Value = 1 }; };
-    template<> struct IsSignedInteger<long>        { enum { Value = 1 }; };
-    template<> struct IsSignedInteger<long long>   { enum { Value = 1 }; };
+    template<typename T> struct IsSignedInteger    { enum JustSomeName__ { Value = 0 }; };
+    template<> struct IsSignedInteger<signed char> { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsSignedInteger<short>       { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsSignedInteger<int>         { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsSignedInteger<long>        { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsSignedInteger<long long>   { enum JustSomeName__ { Value = 1 }; };
 
-    template<typename T> struct IsUnsignedInteger           { enum { Value = 0 }; };
-    template<> struct IsUnsignedInteger<unsigned char>      { enum { Value = 1 }; };
-    template<> struct IsUnsignedInteger<unsigned short>     { enum { Value = 1 }; };
-    template<> struct IsUnsignedInteger<unsigned int>       { enum { Value = 1 }; };
-    template<> struct IsUnsignedInteger<unsigned long>      { enum { Value = 1 }; };
-    template<> struct IsUnsignedInteger<unsigned long long> { enum { Value = 1 }; };
+    template<typename T> struct IsUnsignedInteger           { enum JustSomeName__ { Value = 0 }; };
+    template<> struct IsUnsignedInteger<unsigned char>      { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsUnsignedInteger<unsigned short>     { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsUnsignedInteger<unsigned int>       { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsUnsignedInteger<unsigned long>      { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsUnsignedInteger<unsigned long long> { enum JustSomeName__ { Value = 1 }; };
 
-    template<typename T> struct IsInteger { enum { Value = IsSignedInteger<T>::Value | IsUnsignedInteger<T>::Value }; };
+    template<typename T> struct IsInteger { enum JustSomeName__ { Value = IsSignedInteger<T>::Value | IsUnsignedInteger<T>::Value }; };
 
-    template<typename T> struct IsReal { enum { Value = 0 }; };
-    template<> struct IsReal<float>    { enum { Value = 1 }; };
-    template<> struct IsReal<double>   { enum { Value = 1 }; };
+    template<typename T> struct IsReal { enum JustSomeName__ { Value = 0 }; };
+    template<> struct IsReal<float>    { enum JustSomeName__ { Value = 1 }; };
+    template<> struct IsReal<double>   { enum JustSomeName__ { Value = 1 }; };
 
-    template<typename T, typename U> struct IsEqualType { enum { Value = 0 }; };
-    template<typename T> struct IsEqualType<T, T> { enum { Value = 1 }; };
+    template<typename T, typename U> struct IsEqualType { enum JustSomeName__ { Value = 0 }; };
+    template<typename T> struct IsEqualType<T, T> { enum JustSomeName__ { Value = 1 }; };
 
     template<typename T, typename List0, typename List1 = void, typename List2 = void, typename List3 = void, typename List4 = void, typename List5 = void, typename List6 = void>
-        struct IsInTypelist { enum { Value = false }; };
-    template<typename T, typename List1, typename List2, typename List3, typename List4, typename List5, typename List6> struct IsInTypelist<T, T, List1, List2, List3, List4, List5, List6> { enum { Value = true }; };
-    template<typename T, typename List0, typename List2, typename List3, typename List4, typename List5, typename List6> struct IsInTypelist<T, List0, T, List2, List3, List4, List5, List6> { enum { Value = true }; };
-    template<typename T, typename List0, typename List1, typename List3, typename List4, typename List5, typename List6> struct IsInTypelist<T, List0, List1, T, List3, List4, List5, List6> { enum { Value = true }; };
-    template<typename T, typename List0, typename List1, typename List2, typename List4, typename List5, typename List6> struct IsInTypelist<T, List0, List1, List2, T, List4, List5, List6> { enum { Value = true }; };
-    template<typename T, typename List0, typename List1, typename List2, typename List3, typename List5, typename List6> struct IsInTypelist<T, List0, List1, List2, List3, T, List5, List6> { enum { Value = true }; };
-    template<typename T, typename List0, typename List1, typename List2, typename List3, typename List4, typename List6> struct IsInTypelist<T, List0, List1, List2, List3, List4, T, List6> { enum { Value = true }; };
-    template<typename T, typename List0, typename List1, typename List2, typename List3, typename List4, typename List5> struct IsInTypelist<T, List0, List1, List2, List3, List4, List5, T> { enum { Value = true }; };
+        struct IsInTypelist { enum JustSomeName__ { Value = false }; };
+    template<typename T, typename List1, typename List2, typename List3, typename List4, typename List5, typename List6> struct IsInTypelist<T, T, List1, List2, List3, List4, List5, List6> { enum JustSomeName__ { Value = true }; };
+    template<typename T, typename List0, typename List2, typename List3, typename List4, typename List5, typename List6> struct IsInTypelist<T, List0, T, List2, List3, List4, List5, List6> { enum JustSomeName__ { Value = true }; };
+    template<typename T, typename List0, typename List1, typename List3, typename List4, typename List5, typename List6> struct IsInTypelist<T, List0, List1, T, List3, List4, List5, List6> { enum JustSomeName__ { Value = true }; };
+    template<typename T, typename List0, typename List1, typename List2, typename List4, typename List5, typename List6> struct IsInTypelist<T, List0, List1, List2, T, List4, List5, List6> { enum JustSomeName__ { Value = true }; };
+    template<typename T, typename List0, typename List1, typename List2, typename List3, typename List5, typename List6> struct IsInTypelist<T, List0, List1, List2, List3, T, List5, List6> { enum JustSomeName__ { Value = true }; };
+    template<typename T, typename List0, typename List1, typename List2, typename List3, typename List4, typename List6> struct IsInTypelist<T, List0, List1, List2, List3, List4, T, List6> { enum JustSomeName__ { Value = true }; };
+    template<typename T, typename List0, typename List1, typename List2, typename List3, typename List4, typename List5> struct IsInTypelist<T, List0, List1, List2, List3, List4, List5, T> { enum JustSomeName__ { Value = true }; };
 
-    template<typename Arg0, typename Arg1, typename T0, typename T1> struct IsCombinationOf { enum { Value = false }; };
-    template<typename Arg0, typename Arg1> struct IsCombinationOf<Arg0, Arg1, Arg0, Arg1> { enum { Value = true }; };
-    template<typename Arg0, typename Arg1> struct IsCombinationOf<Arg0, Arg1, Arg1, Arg0> { enum { Value = true }; };
+    template<typename Arg0, typename Arg1, typename T0, typename T1> struct IsCombinationOf { enum JustSomeName__ { Value = false }; };
+    template<typename Arg0, typename Arg1> struct IsCombinationOf<Arg0, Arg1, Arg0, Arg1> { enum JustSomeName__ { Value = true }; };
+    template<typename Arg0, typename Arg1> struct IsCombinationOf<Arg0, Arg1, Arg1, Arg0> { enum JustSomeName__ { Value = true }; };
 
     namespace
     {
@@ -129,7 +129,7 @@ namespace
         static yes test( To) { return yes(); }
 #endif
         static  no test(...) { return  no(); }
-        enum {
+        enum JustSomeName__ {
 #ifdef VC_MSVC
             // I want to test whether implicit cast works. If it works MSVC thinks it should give a warning. Wrong. Shut up.
 #pragma warning(suppress : 4257 4267)
@@ -140,8 +140,8 @@ namespace
 #if defined(VC_GCC) && VC_GCC < 0x40300
     // GCC 4.1 is very noisy because of the float->int and double->int type trait tests. We get
     // around this noise with a little specialization.
-    template<> struct HasImplicitCast<float , int> { enum { Value = true }; };
-    template<> struct HasImplicitCast<double, int> { enum { Value = true }; };
+    template<> struct HasImplicitCast<float , int> { enum JustSomeName__ { Value = true }; };
+    template<> struct HasImplicitCast<double, int> { enum JustSomeName__ { Value = true }; };
 #endif
 
 #ifdef VC_MSVC
@@ -153,33 +153,33 @@ namespace
     //
     // Because the HasImplicitCast specializations can only be implemented after the Vector class
     // was declared we have to write some nasty hacks.
-    template<typename T1, typename T2> struct HasImplicitCast<_Vector<T1>, T2> { enum { Value = false }; };
+    template<typename T1, typename T2> struct HasImplicitCast<_Vector<T1>, T2> { enum JustSomeName__ { Value = false }; };
 #if defined(VC_IMPL_Scalar)
-    template<unsigned int VS, typename T2> struct HasImplicitCast<Vc::Scalar::Mask<VS>, T2> { enum { Value = false }; };
-    template<unsigned int VS> struct HasImplicitCast<Vc::Scalar::Mask<VS>, Vc::Scalar::Mask<VS> > { enum { Value = true }; };
+    template<unsigned int VS, typename T2> struct HasImplicitCast<Vc::Scalar::Mask<VS>, T2> { enum JustSomeName__ { Value = false }; };
+    template<unsigned int VS> struct HasImplicitCast<Vc::Scalar::Mask<VS>, Vc::Scalar::Mask<VS> > { enum JustSomeName__ { Value = true }; };
 #elif defined(VC_IMPL_SSE)
-    template<unsigned int VS, typename T2> struct HasImplicitCast<Vc::SSE::Mask<VS>, T2> { enum { Value = false }; };
-    template<unsigned int VS> struct HasImplicitCast<Vc::SSE::Mask<VS>, Vc::SSE::Mask<VS> > { enum { Value = true }; };
-    template<typename T2> struct HasImplicitCast<Vc::SSE::Float8Mask, T2> { enum { Value = false }; };
-    template<> struct HasImplicitCast<Vc::SSE::Float8Mask, Vc::SSE::Float8Mask> { enum { Value = true }; };
+    template<unsigned int VS, typename T2> struct HasImplicitCast<Vc::SSE::Mask<VS>, T2> { enum JustSomeName__ { Value = false }; };
+    template<unsigned int VS> struct HasImplicitCast<Vc::SSE::Mask<VS>, Vc::SSE::Mask<VS> > { enum JustSomeName__ { Value = true }; };
+    template<typename T2> struct HasImplicitCast<Vc::SSE::Float8Mask, T2> { enum JustSomeName__ { Value = false }; };
+    template<> struct HasImplicitCast<Vc::SSE::Float8Mask, Vc::SSE::Float8Mask> { enum JustSomeName__ { Value = true }; };
 #elif defined(VC_IMPL_AVX)
-    template<unsigned int VectorSize, size_t RegisterWidth, typename T2> struct HasImplicitCast<Vc::AVX::Mask<VectorSize, RegisterWidth>, T2> { enum { Value = false }; };
-    template<unsigned int VectorSize, size_t RegisterWidth> struct HasImplicitCast<Vc::AVX::Mask<VectorSize, RegisterWidth>, Vc::AVX::Mask<VectorSize, RegisterWidth> > { enum { Value = true }; };
+    template<unsigned int VectorSize, size_t RegisterWidth, typename T2> struct HasImplicitCast<Vc::AVX::Mask<VectorSize, RegisterWidth>, T2> { enum JustSomeName__ { Value = false }; };
+    template<unsigned int VectorSize, size_t RegisterWidth> struct HasImplicitCast<Vc::AVX::Mask<VectorSize, RegisterWidth>, Vc::AVX::Mask<VectorSize, RegisterWidth> > { enum JustSomeName__ { Value = true }; };
 #endif
-    template<typename T> struct HasImplicitCast<_Vector<T>, _Vector<T> > { enum { Value = true }; };
-    //template<> struct HasImplicitCast<_Vector<           int>, _Vector<  unsigned int>> { enum { Value = true }; };
-    //template<> struct HasImplicitCast<_Vector<  unsigned int>, _Vector<           int>> { enum { Value = true }; };
-    //template<> struct HasImplicitCast<_Vector<         short>, _Vector<unsigned short>> { enum { Value = true }; };
-    //template<> struct HasImplicitCast<_Vector<unsigned short>, _Vector<         short>> { enum { Value = true }; };
-    template<typename V, size_t Size1, size_t Size2, typename T2> struct HasImplicitCast<Vc::Memory<V, Size1, Size2>, T2> { enum { Value = false }; };
-    template<typename V, size_t Size1, size_t Size2> struct HasImplicitCast<Vc::Memory<V, Size1, Size2>, Vc::Memory<V, Size1, Size2> > { enum { Value = true }; };
+    template<typename T> struct HasImplicitCast<_Vector<T>, _Vector<T> > { enum JustSomeName__ { Value = true }; };
+    //template<> struct HasImplicitCast<_Vector<           int>, _Vector<  unsigned int>> { enum JustSomeName__ { Value = true }; };
+    //template<> struct HasImplicitCast<_Vector<  unsigned int>, _Vector<           int>> { enum JustSomeName__ { Value = true }; };
+    //template<> struct HasImplicitCast<_Vector<         short>, _Vector<unsigned short>> { enum JustSomeName__ { Value = true }; };
+    //template<> struct HasImplicitCast<_Vector<unsigned short>, _Vector<         short>> { enum JustSomeName__ { Value = true }; };
+    template<typename V, size_t Size1, size_t Size2, typename T2> struct HasImplicitCast<Vc::Memory<V, Size1, Size2>, T2> { enum JustSomeName__ { Value = false }; };
+    template<typename V, size_t Size1, size_t Size2> struct HasImplicitCast<Vc::Memory<V, Size1, Size2>, Vc::Memory<V, Size1, Size2> > { enum JustSomeName__ { Value = true }; };
 #undef _Vector
 #endif
 
     template<typename T> struct CanConvertToInt : public HasImplicitCast<T, int> {};
-    template<> struct CanConvertToInt<bool>     { enum { Value = 0 }; };
-    //template<> struct CanConvertToInt<float>    { enum { Value = 0 }; };
-    //template<> struct CanConvertToInt<double>   { enum { Value = 0 }; };
+    template<> struct CanConvertToInt<bool>     { enum JustSomeName__ { Value = 0 }; };
+    //template<> struct CanConvertToInt<float>    { enum JustSomeName__ { Value = 0 }; };
+    //template<> struct CanConvertToInt<double>   { enum JustSomeName__ { Value = 0 }; };
 
     enum TestEnum {};
     VC_STATIC_ASSERT(CanConvertToInt<int>::Value == 1, CanConvertToInt_is_broken);
@@ -202,8 +202,8 @@ namespace
     VC_STATIC_ASSERT(HasImplicitCastTest3::Value ==  true, HasImplicitCast3_is_broken);
     VC_STATIC_ASSERT(HasImplicitCastTest4::Value == false, HasImplicitCast4_is_broken);
 
-    template<typename T> struct IsLikeInteger { enum { Value = !IsReal<T>::Value && CanConvertToInt<T>::Value }; };
-    template<typename T> struct IsLikeSignedInteger { enum { Value = IsLikeInteger<T>::Value && !IsUnsignedInteger<T>::Value }; };
+    template<typename T> struct IsLikeInteger { enum JustSomeName__ { Value = !IsReal<T>::Value && CanConvertToInt<T>::Value }; };
+    template<typename T> struct IsLikeSignedInteger { enum JustSomeName__ { Value = IsLikeInteger<T>::Value && !IsUnsignedInteger<T>::Value }; };
 } // anonymous namespace
 
 #ifndef VC_CHECK_ALIGNMENT

--- a/math/vc/include/Vc/sse/debug.h
+++ b/math/vc/include/Vc/sse/debug.h
@@ -45,7 +45,7 @@ class DebugStream
     private:
         template<typename T, typename V> static void printVector(V _x)
         {
-            enum { Size = sizeof(V) / sizeof(T) };
+            enum JustSomeName__ { Size = sizeof(V) / sizeof(T) };
             union { V v; T m[Size]; } x = { _x };
             std::cerr << '[' << std::setprecision(24) << x.m[0];
             for (int i = 1; i < Size; ++i) {

--- a/math/vc/include/Vc/sse/vector.tcc
+++ b/math/vc/include/Vc/sse/vector.tcc
@@ -1389,7 +1389,7 @@ template<> Vc_ALWAYS_INLINE Vector<double> Vector<double>::Random()
 // shifted / rotated {{{1
 template<typename T> Vc_INTRINSIC Vc_PURE Vector<T> Vector<T>::shifted(int amount) const
 {
-    enum {
+    enum JustSomeName__ {
         EntryTypeSizeof = sizeof(EntryType)
     };
     switch (amount) {
@@ -1415,7 +1415,7 @@ template<typename T> Vc_INTRINSIC Vc_PURE Vector<T> Vector<T>::shifted(int amoun
 }
 template<> Vc_INTRINSIC Vc_PURE sfloat_v sfloat_v::shifted(int amount) const
 {
-    enum {
+    enum JustSomeName__ {
         EntryTypeSizeof = sizeof(EntryType)
     };
     switch (amount) {
@@ -1439,7 +1439,7 @@ template<> Vc_INTRINSIC Vc_PURE sfloat_v sfloat_v::shifted(int amount) const
 }
 template<typename T> Vc_INTRINSIC Vc_PURE Vector<T> Vector<T>::rotated(int amount) const
 {
-    enum {
+    enum JustSomeName__ {
         EntryTypeSizeof = sizeof(EntryType)
     };
     const __m128i v = mm128_reinterpret_cast<__m128i>(d.v());
@@ -1460,7 +1460,7 @@ template<typename T> Vc_INTRINSIC Vc_PURE Vector<T> Vector<T>::rotated(int amoun
 }
 template<> Vc_INTRINSIC Vc_PURE sfloat_v sfloat_v::rotated(int amount) const
 {
-    enum {
+    enum JustSomeName__ {
         EntryTypeSizeof = sizeof(EntryType)
     };
     const __m128i v0 = sse_cast<__m128i>(d.v()[0]);

--- a/math/vc/include/Vc/version.h
+++ b/math/vc/include/Vc/version.h
@@ -20,8 +20,8 @@
 #ifndef VC_VERSION_H
 #define VC_VERSION_H
 
-#define VC_VERSION_STRING "0.7.4"
-#define VC_VERSION_NUMBER 0x000708
+#define VC_VERSION_STRING "0.7.4-dev"
+#define VC_VERSION_NUMBER 0x000709
 #define VC_VERSION_CHECK(major, minor, patch) ((major << 16) | (minor << 8) | (patch << 1))
 #define VC_LIBRARY_ABI_VERSION 3
 


### PR DESCRIPTION
Summary of the changes in Vc 0.7.4:
* fixed several compile errors / warnings with newer or old C++
  compilers
* support clean compilation with more -W flags
* fixed compilation when compiling without optimization
* added operator-- to Vector<T>
* Copying Memory now uses SIMD move instructions
* Vc::Allocator<T> now uses a minimum alignment of the SIMD types of
  the chosen Vc implementation. Thus making it useable for containers of
  builtin types.

Signed-off-by: Matthias Kretz <kretz@kde.org>