### PR TITLE
Thread safe TListOfFunctions

### DIFF
--- a/core/meta/inc/LinkDef.h
+++ b/core/meta/inc/LinkDef.h
@@ -66,6 +66,7 @@
 #pragma link C++ class std::vector<std::pair<Int_t, Int_t> >+;
 #pragma link C++ class TFileMergeInfo;
 #pragma link C++ class TListOfFunctions+;
+#pragma link C++ class TListOfFunctionsIter;
 #pragma link C++ class TListOfFunctionTemplates+;
 #pragma link C++ class TListOfDataMembers-;
 #pragma link C++ class TListOfEnums+;

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -187,7 +187,7 @@ private:
    TListOfDataMembers*fData;            //linked list for data members
    TListOfEnums      *fEnums;           //linked list for the enums
    TListOfFunctionTemplates *fFuncTemplate; //linked list for function templates [Not public until implemented as active list]
-   TListOfFunctions  *fMethod;          //linked list for methods
+   std::atomic<TListOfFunctions*> fMethod;          //linked list for methods
    TViewPubDataMembers*fAllPubData;      //all public data members (including from base classes)
    TViewPubFunctions *fAllPubMethod;    //all public methods (including from base classes)
    mutable TList     *fClassMenuList;   //list of class menu items

--- a/core/meta/inc/TListOfFunctions.h
+++ b/core/meta/inc/TListOfFunctions.h
@@ -63,10 +63,26 @@ public:
    virtual void Clear(Option_t *option);
    virtual void Delete(Option_t *option="");
 
-   using THashList::FindObject;
+   virtual TObject   *FindObject(const TObject* obj) const;
    virtual TObject   *FindObject(const char *name) const;
    virtual TList     *GetListForObject(const char* name) const;
    virtual TList     *GetListForObject(const TObject* obj) const;
+   virtual TIterator *MakeIterator(Bool_t dir = kIterForward) const;
+
+   virtual TObject  *At(Int_t idx) const;
+   virtual TObject  *After(const TObject *obj) const;
+   virtual TObject  *Before(const TObject *obj) const;
+   virtual TObject  *First() const;
+   virtual TObjLink *FirstLink() const;
+   virtual TObject **GetObjectRef(const TObject *obj) const;
+   virtual TObject  *Last() const;
+   virtual TObjLink *LastLink() const;
+
+   virtual Int_t     GetLast() const;
+   virtual Int_t     IndexOf(const TObject *obj) const;
+
+   virtual Int_t      GetSize() const;
+
 
    TFunction *Get(DeclId_t id);
 
@@ -90,5 +106,25 @@ public:
 
    ClassDef(TListOfFunctions,0);  // List of TFunctions for a class
 };
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TListOfFunctionsIter                                                 //
+//                                                                      //
+// Iterator of TListOfFunctions.                                        //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+class TListOfFunctionsIter : public TListIter
+{
+ public:
+   TListOfFunctionsIter(const TListOfFunctions *l, Bool_t dir = kIterForward);
+
+   using TListIter::operator=;
+
+   TObject           *Next();
+
+   ClassDef(TListOfFunctionsIter,0)
+};
+
 
 #endif // ROOT_TListOfFunctions

--- a/core/meta/src/TListOfFunctions.cxx
+++ b/core/meta/src/TListOfFunctions.cxx
@@ -176,10 +176,9 @@ TObject *TListOfFunctions::FindObject(const char *name) const
    // Specialize FindObject to do search for the
    // a function just by name or create it if its not already in the list
 
+   R__LOCKGUARD(gInterpreterMutex);
    TObject *result = THashList::FindObject(name);
    if (!result) {
-
-      R__LOCKGUARD(gInterpreterMutex);
 
       TInterpreter::DeclId_t decl;
       if (fClass) decl = gInterpreter->GetFunction(fClass->GetClassInfo(),name);
@@ -254,6 +253,7 @@ TFunction *TListOfFunctions::Get(DeclId_t id)
 
    if (!id) return 0;
 
+   R__LOCKGUARD(gInterpreterMutex);
    TFunction *f = (TFunction*)fIds->GetValue((Long64_t)id);
    if (!f) {
       if (fClass) {
@@ -261,8 +261,6 @@ TFunction *TListOfFunctions::Get(DeclId_t id)
       } else {
          if (!gInterpreter->ClassInfo_Contains(0,id)) return 0;
       }
-
-      R__LOCKGUARD(gInterpreterMutex);
 
       MethodInfo_t *m = gInterpreter->MethodInfo_Factory(id);
 
@@ -425,4 +423,118 @@ void TListOfFunctions::Unload(TFunction *func)
       fIds->Remove((Long64_t)func->GetDeclId());
       fUnloaded->Add(func);
    }
+}
+
+//______________________________________________________________________________
+TObject* TListOfFunctions::FindObject(const TObject* obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::FindObject(obj);
+}
+
+//______________________________________________________________________________
+TIterator* TListOfFunctions::MakeIterator(Bool_t dir ) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return new TListOfFunctionsIter(this,dir);
+}
+
+//______________________________________________________________________________
+TObject* TListOfFunctions::At(Int_t idx) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::At(idx);
+}
+
+//______________________________________________________________________________
+TObject* TListOfFunctions::After(const TObject *obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::After(obj);
+}
+
+//______________________________________________________________________________
+TObject* TListOfFunctions::Before(const TObject *obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::Before(obj);
+}
+
+//______________________________________________________________________________
+TObject* TListOfFunctions::First() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::First();
+}
+
+//______________________________________________________________________________
+TObjLink* TListOfFunctions::FirstLink() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::FirstLink();
+}
+
+//______________________________________________________________________________
+TObject** TListOfFunctions::GetObjectRef(const TObject *obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::GetObjectRef(obj);
+}
+
+//______________________________________________________________________________
+TObject* TListOfFunctions::Last() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::Last();
+}
+
+//______________________________________________________________________________
+TObjLink* TListOfFunctions::LastLink() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::LastLink();
+}
+
+
+//______________________________________________________________________________
+Int_t TListOfFunctions::GetLast() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::GetLast();
+}
+
+//______________________________________________________________________________
+Int_t TListOfFunctions::IndexOf(const TObject *obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::IndexOf(obj);
+}
+
+
+//______________________________________________________________________________
+Int_t TListOfFunctions::GetSize() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return THashList::GetSize();
+}
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TListOfFunctionsIter                                                 //
+//                                                                      //
+// Iterator for TListOfFunctions.                                       //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+ClassImp(TListOfFunctionsIter)
+
+//______________________________________________________________________________
+TListOfFunctionsIter::TListOfFunctionsIter(const TListOfFunctions *l, Bool_t dir ):
+  TListIter(l,dir) {}
+
+//______________________________________________________________________________
+TObject *TListOfFunctionsIter::Next()
+{
+  R__LOCKGUARD(gInterpreterMutex);
+  return TListIter::Next();
 }


### PR DESCRIPTION
Thread safety issues with TListOfFunctions was found using the CMS threaded framework. These changes were done in consultation with Philippe Canal.