### PR TITLE
Assign directly to static variable to avoid race condition

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -420,10 +420,7 @@ Bool_t TFormula::AnalyzeFunction(TString &chaine, Int_t &err, Int_t offset)
 
    // ROOT does yet have a complete TType class, but TCling does,
    // so let's use that for now.
-   static TypeInfo_t *doubletype = 0;
-   if (doubletype == 0) {
-      doubletype = gInterpreter->TypeInfo_Factory("double");
-   }
+   static TypeInfo_t * const doubletype{ gInterpreter->TypeInfo_Factory("double") };
    std::vector<TypeInfo_t*> proto(nargs,doubletype);
 
    CallFunc_t *callfunc = gInterpreter->CallFunc_Factory();


### PR DESCRIPTION
Initialization of a function static variable is guaranteed to be
done in a thread safe manner by the C++11 standard. Previously, the
static was initialized to 0 and then reset which lead to a data race.