### PR TITLE
TNetXNGFile: explicitly include XrdVersion.hh

### DIFF
--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -24,6 +24,7 @@
 #include "TTimeStamp.h"
 #include "TVirtualPerfStats.h"
 #include "TVirtualMonitoring.h"
+#include <XrdVersion.hh>
 #include <XrdCl/XrdClURL.hh>
 #include <XrdCl/XrdClFile.hh>
 #include <XrdCl/XrdClXRootDResponses.hh>


### PR DESCRIPTION
Fixes compilation with xrootd v4:

```
/Users/veprbl/root/net/netxng/src/TNetXNGFile.cxx:670:26: error: no member named 'GetDataServer' in 'XrdCl::File'
URL dataServer(fFile->GetDataServer());
~~~~~ ^
1 error generated.
```