### PR TITLE
Thread-safe TClass enums and TCling return values

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -185,7 +185,7 @@ private:
    TList             *fRealData;        //linked list for persistent members including base classes
    TList             *fBase;            //linked list for base classes
    TListOfDataMembers*fData;            //linked list for data members
-   TListOfEnums      *fEnums;           //linked list for the enums
+   std::atomic<TListOfEnums*> fEnums;       //linked list for the enums
    TListOfFunctionTemplates *fFuncTemplate; //linked list for function templates [Not public until implemented as active list]
    std::atomic<TListOfFunctions*> fMethod;          //linked list for methods
    TViewPubDataMembers*fAllPubData;      //all public data members (including from base classes)

--- a/core/meta/src/TCling.cxx
+++ b/core/meta/src/TCling.cxx
@@ -174,7 +174,7 @@ extern "C" {
 #define dlopen(library_name, flags) ::LoadLibraryEx(library_name, NULL, DONT_RESOLVE_DLL_REFERENCES)
 #define dlclose(library) ::FreeLibrary((HMODULE)library)
 char *dlerror() {
-   static char Msg[1000];
+   thread_local char Msg[1000];
    FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(),
                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), Msg,
                  sizeof(Msg), NULL);
@@ -1150,7 +1150,7 @@ static const char *FindLibraryName(void (*func)())
    }
 
    HMODULE hMod = (HMODULE) mbi.AllocationBase;
-   static char moduleName[MAX_PATH];
+   thread_local char moduleName[MAX_PATH];
 
    if (!GetModuleFileNameA (hMod, moduleName, sizeof (moduleName)))
    {
@@ -1380,7 +1380,7 @@ void TCling::RegisterModule(const char* modulename,
    // The value of 'triggerFunc' is used to find the shared library location.
 
    // rootcling also uses TCling for generating the dictionary ROOT files.
-   static bool fromRootCling = dlsym(RTLD_DEFAULT, "usedToIdentifyRootClingByDlSym");
+   static const bool fromRootCling = dlsym(RTLD_DEFAULT, "usedToIdentifyRootClingByDlSym");
    // We need the dictionary initialization but we don't want to inject the
    // declarations into the interpreter, except for those we really need for
    // I/O; see rootcling.cxx after the call to TCling__GetInterpreter().
@@ -1937,7 +1937,7 @@ void TCling::InspectMembers(TMemberInspector& insp, const void* obj,
       return;
    }
 
-   static TClassRef clRefString("std::string");
+   static const TClassRef clRefString("std::string");
    if (clRefString == cl) {
       // We stream std::string without going through members..
       return;
@@ -5838,7 +5838,7 @@ Bool_t TCling::LoadText(const char* text) const
 const char* TCling::MapCppName(const char* name) const
 {
    // Interface to cling function
-   static std::string buffer;
+   thread_local std::string buffer;
    ROOT::TMetaUtils::GetCppName(buffer,name);
    return buffer.c_str();
 }
@@ -6521,7 +6521,7 @@ const char* TCling::ClassInfo_FileName(ClassInfo_t* cinfo) const
 const char* TCling::ClassInfo_FullName(ClassInfo_t* cinfo) const
 {
    TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
-   static std::string output;
+   thread_local std::string output;
    TClinginfo->FullName(output,*fNormalizedCtxt);
    return output.c_str();
 }
@@ -6636,7 +6636,7 @@ Long_t TCling::BaseClassInfo_Tagnum(BaseClassInfo_t* bcinfo) const
 const char* TCling::BaseClassInfo_FullName(BaseClassInfo_t* bcinfo) const
 {
    TClingBaseClassInfo* TClinginfo = (TClingBaseClassInfo*) bcinfo;
-   static std::string output;
+   thread_local std::string output;
    TClinginfo->FullName(output,*fNormalizedCtxt);
    return output.c_str();
 }
@@ -7114,7 +7114,7 @@ TypeInfo_t* TCling::MethodInfo_Type(MethodInfo_t* minfo) const
 const char* TCling::MethodInfo_GetMangledName(MethodInfo_t* minfo) const
 {
    TClingMethodInfo* info = (TClingMethodInfo*) minfo;
-   static TString mangled_name;
+   thread_local  TString mangled_name;
    mangled_name = info->GetMangledName();
    return mangled_name;
 }

--- a/core/meta/src/TClingMethodArgInfo.cxx
+++ b/core/meta/src/TClingMethodArgInfo.cxx
@@ -128,7 +128,7 @@ const char *TClingMethodArgInfo::DefaultValue() const
    }
    clang::ASTContext &context = pvd->getASTContext();
    clang::PrintingPolicy policy(context.getPrintingPolicy());
-   static std::string buf;
+   thread_local std::string buf;
    buf.clear();
    llvm::raw_string_ostream out(buf);
    if (!expr) {
@@ -165,7 +165,7 @@ const char *TClingMethodArgInfo::Name() const
    }
    const clang::FunctionDecl *fd = fMethodInfo->GetMethodDecl();
    const clang::ParmVarDecl *pvd = fd->getParamDecl(fIdx);
-   static std::string buf;
+   thread_local std::string buf;
    buf.clear();
    clang::PrintingPolicy policy(pvd->getASTContext().getPrintingPolicy());
    llvm::raw_string_ostream stream(buf);
@@ -176,7 +176,7 @@ const char *TClingMethodArgInfo::Name() const
 
 const TClingTypeInfo *TClingMethodArgInfo::Type() const
 {
-   static TClingTypeInfo ti(fInterp);
+   thread_local TClingTypeInfo ti(fInterp);
    if (!IsValid()) {
       return &ti;
    }

--- a/core/meta/src/TClingMethodInfo.cxx
+++ b/core/meta/src/TClingMethodInfo.cxx
@@ -443,7 +443,7 @@ long TClingMethodInfo::ExtraProperty() const
 
 TClingTypeInfo *TClingMethodInfo::Type() const
 {
-   static TClingTypeInfo ti(fInterp);
+   thread_local TClingTypeInfo ti(fInterp);
    if (!IsValid()) {
       ti.Init(clang::QualType());
       return &ti;
@@ -489,7 +489,7 @@ const char *TClingMethodInfo::GetPrototype(const ROOT::TMetaUtils::TNormalizedCt
    if (!IsValid()) {
       return 0;
    }
-   static std::string buf;
+   thread_local std::string buf;
    buf.clear();
    buf += Type()->Name();
    buf += ' ';
@@ -542,7 +542,7 @@ const char *TClingMethodInfo::Name(const ROOT::TMetaUtils::TNormalizedCtxt &norm
    if (!IsValid()) {
       return 0;
    }
-   static std::string buf;
+   thread_local std::string buf;
    ((TCling*)gCling)->GetFunctionName(GetMethodDecl(),buf);
    return buf.c_str();
 }

--- a/core/meta/src/TClingTypeInfo.cxx
+++ b/core/meta/src/TClingTypeInfo.cxx
@@ -103,7 +103,7 @@ const char *TClingTypeInfo::Name() const
       return "";
    }
    // Note: This *must* be static because we are returning a pointer inside it!
-   static std::string buf;
+   thread_local std::string buf;
    buf.clear();
 
    ROOT::TMetaUtils::GetFullyQualifiedTypeName(buf,fQualType,*fInterp);
@@ -276,7 +276,7 @@ const char *TClingTypeInfo::StemName() const
       break;
    }
    // Note: This *must* be static because we are returning a pointer inside it.
-   static std::string buf;
+   thread_local std::string buf;
    buf.clear();
    clang::PrintingPolicy Policy(fInterp->getCI()->getASTContext().
                                 getPrintingPolicy());
@@ -294,7 +294,7 @@ const char *TClingTypeInfo::TrueName(const ROOT::TMetaUtils::TNormalizedCtxt &no
       return 0;
    }
    // Note: This *must* be static because we are returning a pointer inside it.
-   static std::string buf;
+   thread_local std::string buf;
    buf.clear();
 
    ROOT::TMetaUtils::GetNormalizedName(buf,fQualType, *fInterp, normCtxt);

--- a/core/meta/src/TClingTypedefInfo.cxx
+++ b/core/meta/src/TClingTypedefInfo.cxx
@@ -271,7 +271,7 @@ const char *TClingTypedefInfo::TrueName(const ROOT::TMetaUtils::TNormalizedCtxt 
       return "(unknown)";
    }
    // Note: This must be static because we return a pointer to the internals.
-   static std::string truename;
+   thread_local std::string truename;
    truename.clear();
    const clang::TypedefNameDecl *td = llvm::dyn_cast<clang::TypedefNameDecl>(fDecl);
    clang::QualType underlyingType = td->getUnderlyingType();
@@ -292,7 +292,7 @@ const char *TClingTypedefInfo::Name() const
       return "(unknown)";
    }
    // Note: This must be static because we return a pointer to the internals.
-   static std::string fullname;
+   thread_local std::string fullname;
    fullname.clear();
    const clang::TypedefNameDecl *td = llvm::dyn_cast<clang::TypedefNameDecl>(fDecl);
    const clang::ASTContext &ctxt = fDecl->getASTContext();

--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -232,7 +232,7 @@ const char *TDataType::AsString(void *buf) const
    // Return string containing value in buffer formatted according to
    // the basic data type. The result needs to be used or copied immediately.
 
-   static TString line(81);
+   thread_local TString line(81);
    const char *name;
 
    if (fInfo) {

--- a/core/meta/src/TProtoClass.cxx
+++ b/core/meta/src/TProtoClass.cxx
@@ -258,9 +258,12 @@ Bool_t TProtoClass::FillTClass(TClass* cl) {
 
    // We need to fill enums one by one to initialise the internal map which is
    // transient
-   cl->fEnums = new TListOfEnums();
-   for (TObject* enumAsTObj : *fEnums){
-      cl->fEnums->Add((TEnum*) enumAsTObj);
+   {
+      auto temp = new TListOfEnums();
+      for (TObject* enumAsTObj : *fEnums){
+         temp->Add((TEnum*) enumAsTObj);
+      }
+      cl->fEnums = temp;
    }
   
    cl->fSizeof = fSizeof;


### PR DESCRIPTION
Made obtaining the list of enums from a TClass thread safe. As part of that, made all the statics used as return values by TCling to be thread_local.
