### PR TITLE
Thread-safe interaction with all enum lists

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -111,7 +111,7 @@
 #include "TInterpreter.h"
 #include "TListOfTypes.h"
 #include "TListOfDataMembers.h"
-#include "TListOfEnums.h"
+#include "TListOfEnumsWithLock.h"
 #include "TListOfFunctions.h"
 #include "TListOfFunctionTemplates.h"
 #include "TFunctionTemplate.h"
@@ -1367,8 +1367,9 @@ TObject *TROOT::GetGeometry(const char *name) const
 //______________________________________________________________________________
 TCollection *TROOT::GetListOfEnums()
 {
+   R__LOCKGUARD2(gROOTMutex);
    if(!fEnums) {
-      fEnums = new TListOfEnums(0);
+      fEnums = new TListOfEnumsWithLock(0);
    }
    return fEnums;
 }

--- a/core/meta/inc/LinkDef.h
+++ b/core/meta/inc/LinkDef.h
@@ -70,6 +70,8 @@
 #pragma link C++ class TListOfFunctionTemplates+;
 #pragma link C++ class TListOfDataMembers-;
 #pragma link C++ class TListOfEnums+;
+#pragma link C++ class TListOfEnumsWithLock+;
+#pragma link C++ class TListOfEnumsWithLockIter;
 //for new protoclasses
 #pragma link C++ class std::vector<TDataMember * >+;
 #pragma link C++ class std::vector<TProtoClass::TProtoRealData >+;

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -40,6 +40,7 @@ class TInterpreterValue;
 class TMethod;
 class TObjArray;
 class TEnum;
+class TListOfEnums;
 
 R__EXTERN TVirtualMutex *gInterpreterMutex;
 
@@ -245,7 +246,7 @@ public:
    virtual DeclId_t GetEnum(TClass *cl, const char *name) const = 0;
    virtual TEnum*   CreateEnum(void *VD, TClass *cl) const = 0;
    virtual void     UpdateEnumConstants(TEnum* enumObj, TClass* cl) const = 0;
-   virtual void     LoadEnums(TClass* cl) const = 0;
+   virtual void     LoadEnums(TListOfEnums& cl) const = 0;
    virtual DeclId_t GetFunction(ClassInfo_t *cl, const char *funcname) = 0;
    virtual DeclId_t GetFunctionWithPrototype(ClassInfo_t *cl, const char* method, const char* proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch) = 0;
    virtual DeclId_t GetFunctionWithValues(ClassInfo_t *cl, const char* method, const char* params, Bool_t objectIsConst = kFALSE) = 0;

--- a/core/meta/inc/TListOfEnums.h
+++ b/core/meta/inc/TListOfEnums.h
@@ -36,6 +36,10 @@ class TEnum;
 class TListOfEnums : public THashList
 {
 private:
+   friend class TCling;
+   friend class TClass;
+   friend class TProtoClass;
+
    typedef TDictionary::DeclId_t DeclId_t;
    TClass    *fClass; //! Context of this list.  Not owned.
 
@@ -44,44 +48,45 @@ private:
    Bool_t     fIsLoaded; //! Mark whether Load was executed.
    ULong64_t  fLastLoadMarker; //! Represent interpreter state when we last did a full load.
 
-   TListOfEnums(const TListOfEnums&);              // not implemented
-   TListOfEnums& operator=(const TListOfEnums&);   // not implemented
+   TListOfEnums(const TListOfEnums&) = delete;
+   TListOfEnums& operator=(const TListOfEnums&) = delete;
 
    void       MapObject(TObject *obj);
    void       UnmapObject(TObject *obj);
-
-public:
-
-   TListOfEnums(TClass *cl = 0);
-   ~TListOfEnums();
-
-   virtual void Clear(Option_t *option);
-   virtual void Delete(Option_t *option="");
-
-   using THashList::FindObject;
-   virtual TObject   *FindObject(const char *name) const;
-
-   TEnum *Get(DeclId_t id, const char *name);
-
-   Bool_t     IsLoaded() const { return fIsLoaded; }
-   void       AddFirst(TObject *obj);
-   void       AddFirst(TObject *obj, Option_t *opt);
-   void       AddLast(TObject *obj);
-   void       AddLast(TObject *obj, Option_t *opt);
-   void       AddAt(TObject *obj, Int_t idx);
-   void       AddAfter(const TObject *after, TObject *obj);
-   void       AddAfter(TObjLink *after, TObject *obj);
-   void       AddBefore(const TObject *before, TObject *obj);
-   void       AddBefore(TObjLink *before, TObject *obj);
-
-   void       RecursiveRemove(TObject *obj);
-   TObject   *Remove(TObject *obj);
-   TObject   *Remove(TObjLink *lnk);
 
    void Load();
    void Unload();
    void Unload(TEnum *e);
    void       SetClass(TClass* cl) { fClass = cl; }
+
+protected:
+   TClass* GetClass() const {return fClass;}
+   TExMap* GetIds() { return fIds;}
+   TEnum* FindUnloaded(const char* name) { return (TEnum*)fUnloaded->FindObject(name);}
+   TEnum *Get(DeclId_t id, const char *name);
+
+public:
+
+   TListOfEnums(TClass *cl = 0);
+   ~TListOfEnums() override;
+
+   void Clear(Option_t *option) override;
+   void Delete(Option_t *option="") override;
+
+   Bool_t     IsLoaded() const { return fIsLoaded; }
+   void       AddFirst(TObject *obj) override;
+   void       AddFirst(TObject *obj, Option_t *opt) override;
+   void       AddLast(TObject *obj) override;
+   void       AddLast(TObject *obj, Option_t *opt) override;
+   void       AddAt(TObject *obj, Int_t idx) override;
+   void       AddAfter(const TObject *after, TObject *obj) override;
+   void       AddAfter(TObjLink *after, TObject *obj) override;
+   void       AddBefore(const TObject *before, TObject *obj) override;
+   void       AddBefore(TObjLink *before, TObject *obj) override;
+
+   void       RecursiveRemove(TObject *obj) override;
+   TObject   *Remove(TObject *obj) override;
+   TObject   *Remove(TObjLink *lnk) override;
 
    ClassDef(TListOfEnums,2);  // List of TDataMembers for a class
 };

--- a/core/meta/inc/TListOfEnumsWithLock.h
+++ b/core/meta/inc/TListOfEnumsWithLock.h
@@ -1,0 +1,103 @@
+// @(#)root/cont
+// Author: Bianca-Cristina Cristescu February 2014
+
+/*************************************************************************
+ * Copyright (C) 1995-2013, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TListOfEnumsWithLock
+#define ROOT_TListOfEnumsWithLock
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TListOfEnumsWithLock                                                         //
+//                                                                      //
+// A collection of TEnum objects designed for fast access given a       //
+// DeclId_t and for keep track of TEnum that were described             //
+// unloaded enum.                                                       //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef ROOT_TListOfEnums
+#include "TListOfEnums.h"
+#endif
+
+class TExMap;
+class TEnum;
+
+class TListOfEnumsWithLock : public TListOfEnums
+{
+private:
+   typedef TDictionary::DeclId_t DeclId_t;
+
+   TListOfEnumsWithLock(const TListOfEnumsWithLock&) = delete;
+   TListOfEnumsWithLock& operator=(const TListOfEnumsWithLock&) = delete;
+
+public:
+
+   TListOfEnumsWithLock(TClass *cl = 0);
+   ~TListOfEnumsWithLock() override;
+
+   void Clear(Option_t *option) override;
+   void Delete(Option_t *option="") override;
+
+   TObject   *FindObject(const TObject* obj) const override;
+   TObject   *FindObject(const char *name) const override;
+   TIterator *MakeIterator(Bool_t dir = kIterForward) const override;
+
+   TObject  *At(Int_t idx) const override;
+   TObject  *After(const TObject *obj) const override;
+   TObject  *Before(const TObject *obj) const override;
+   TObject  *First() const override;
+   TObjLink *FirstLink() const override;
+   TObject **GetObjectRef(const TObject *obj) const override;
+   TObject  *Last() const override;
+   TObjLink *LastLink() const override;
+
+   Int_t     GetLast() const override;
+   Int_t     IndexOf(const TObject *obj) const override;
+
+   Int_t      GetSize() const override;
+
+   void       AddFirst(TObject *obj) override;
+   void       AddFirst(TObject *obj, Option_t *opt) override;
+   void       AddLast(TObject *obj) override;
+   void       AddLast(TObject *obj, Option_t *opt) override;
+   void       AddAt(TObject *obj, Int_t idx) override;
+   void       AddAfter(const TObject *after, TObject *obj) override;
+   void       AddAfter(TObjLink *after, TObject *obj) override;
+   void       AddBefore(const TObject *before, TObject *obj) override;
+   void       AddBefore(TObjLink *before, TObject *obj) override;
+
+   void       RecursiveRemove(TObject *obj) override;
+   TObject   *Remove(TObject *obj) override;
+   TObject   *Remove(TObjLink *lnk) override;
+
+   ClassDef(TListOfEnumsWithLock,2);  // List of TDataMembers for a class
+};
+
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TListOfEnumsWithLockIter                                             //
+//                                                                      //
+// Iterator of TListOfEnumsWithLock.                                    //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+class TListOfEnumsWithLockIter : public TListIter
+{
+ public:
+   TListOfEnumsWithLockIter(const TListOfEnumsWithLock *l, Bool_t dir = kIterForward);
+
+   using TListIter::operator=;
+
+   TObject           *Next();
+
+   ClassDef(TListOfEnumsWithLockIter,0)
+};
+
+#endif // ROOT_TListOfEnumsWithLock

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3328,7 +3328,7 @@ TList *TClass::GetListOfEnums(Bool_t load /* = kTRUE */)
    }
 
    if(not load) {
-     if(! ((kIsClass | kIsStruct | kIsUnion) & fProperty) ) {
+      if(! ((kIsClass | kIsStruct | kIsUnion) & Property()) ) {
          R__LOCKGUARD(gInterpreterMutex);
          if(fEnums) {
             return fEnums.load();
@@ -3346,7 +3346,7 @@ TList *TClass::GetListOfEnums(Bool_t load /* = kTRUE */)
    if(fEnums) {
       return fEnums.load();
    }
-   if( (kIsClass | kIsStruct | kIsUnion) & fProperty) {
+   if( (kIsClass | kIsStruct | kIsUnion) & Property()) {
       // For this case, the list will be immutable
       temp = new TListOfEnums(this);
    } else {

--- a/core/meta/src/TCling.cxx
+++ b/core/meta/src/TCling.cxx
@@ -3167,20 +3167,18 @@ void TCling::CreateListOfBaseClasses(TClass *cl) const
 }
 
 //______________________________________________________________________________
-void TCling::LoadEnums(TClass* cl) const
+void TCling::LoadEnums(TListOfEnums& enumList) const
 {
    // Create list of pointers to enums for TClass cl.
    R__LOCKGUARD2(gInterpreterMutex);
 
    const Decl * D;
-   TListOfEnums* enumList;
+   TClass* cl = enumList.GetClass();
    if (cl) {
       D = ((TClingClassInfo*)cl->GetClassInfo())->GetDecl();
-      enumList = (TListOfEnums*)cl->GetListOfEnums(false);
    }
    else {
       D = fInterpreter->getCI()->getASTContext().getTranslationUnitDecl();
-      enumList = (TListOfEnums*)gROOT->GetListOfEnums();
    }
    // Iterate on the decl of the class and get the enums.
    if (const clang::DeclContext* DC = dyn_cast<clang::DeclContext>(D)) {
@@ -3204,7 +3202,7 @@ void TCling::LoadEnums(TClass* cl) const
                if (!buf.empty()) {
                   const char* name = buf.c_str();
                   // Add the enum to the list of loaded enums.
-                  enumList->Get(ED, name);
+                  enumList.Get(ED, name);
                }
             }
          }

--- a/core/meta/src/TCling.h
+++ b/core/meta/src/TCling.h
@@ -238,7 +238,7 @@ public: // Public Interface
    virtual DeclId_t GetEnum(TClass *cl, const char *name) const;
    virtual TEnum*   CreateEnum(void *VD, TClass *cl) const;
    virtual void     UpdateEnumConstants(TEnum* enumObj, TClass* cl) const;
-   virtual void     LoadEnums(TClass* cl) const;
+   virtual void     LoadEnums(TListOfEnums& cl) const;
    TString GetMangledName(TClass* cl, const char* method, const char* params, Bool_t objectIsConst = kFALSE);
    TString GetMangledNameWithPrototype(TClass* cl, const char* method, const char* proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    void*   GetInterfaceMethod(TClass* cl, const char* method, const char* params, Bool_t objectIsConst = kFALSE);

--- a/core/meta/src/TListOfEnums.cxx
+++ b/core/meta/src/TListOfEnums.cxx
@@ -177,25 +177,6 @@ void TListOfEnums::Delete(Option_t *option /* ="" */)
 }
 
 //______________________________________________________________________________
-TObject *TListOfEnums::FindObject(const char *name) const
-{
-   // Specialize FindObject to do search for the
-   // a enum just by name or create it if its not already in the list
-
-   TObject *result = THashList::FindObject(name);
-   if (!result) {
-
-      R__LOCKGUARD(gInterpreterMutex);
-
-      TInterpreter::DeclId_t decl;
-      if (fClass) decl = gInterpreter->GetEnum(fClass, name);
-      else        decl = gInterpreter->GetEnum(0, name);
-      if (decl) result = const_cast<TListOfEnums *>(this)->Get(decl, name);
-   }
-   return result;
-}
-
-//______________________________________________________________________________
 TEnum *TListOfEnums::Get(DeclId_t id, const char *name)
 {
    // Return (after creating it if necessary) the TEnum
@@ -260,6 +241,7 @@ TEnum *TListOfEnums::Get(DeclId_t id, const char *name)
 
    return e;
 }
+
 
 //______________________________________________________________________________
 void TListOfEnums::UnmapObject(TObject *obj)

--- a/core/meta/src/TListOfEnums.cxx
+++ b/core/meta/src/TListOfEnums.cxx
@@ -357,7 +357,7 @@ void TListOfEnums::Load()
    // We cannot clear the whole unloaded list. It is too much.
 //   fUnloaded->Clear();
 
-   gInterpreter->LoadEnums(fClass);
+   gInterpreter->LoadEnums(*this);
 }
 
 //______________________________________________________________________________

--- a/core/meta/src/TListOfEnumsWithLock.cxx
+++ b/core/meta/src/TListOfEnumsWithLock.cxx
@@ -1,0 +1,326 @@
+// @(#)root/cont
+// Author: Bianca-Cristina Cristescu February 2014
+
+/*************************************************************************
+ * Copyright (C) 1995-2013, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TListOfEnumsWithLock                                                         //
+//                                                                      //
+// A collection of TEnum objects designed for fast access given a       //
+// DeclId_t and for keep track of TEnum that were described             //
+// unloaded enum.                                                       //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include <forward_list>
+
+#include "TListOfEnumsWithLock.h"
+#include "TClass.h"
+#include "TExMap.h"
+#include "TEnum.h"
+#include "TGlobal.h"
+#include "TInterpreter.h"
+#include "TVirtualMutex.h"
+
+constexpr unsigned int listSize=3;
+
+ClassImp(TListOfEnumsWithLock)
+
+//______________________________________________________________________________
+TListOfEnumsWithLock::TListOfEnumsWithLock(TClass *cl /*=0*/) :
+   TListOfEnums(cl)
+{
+}
+
+//______________________________________________________________________________
+TListOfEnumsWithLock::~TListOfEnumsWithLock()
+{
+   // Destructor.
+
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddFirst(TObject *obj)
+{
+   // Add object at the beginning of the list.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddFirst(obj);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddFirst(TObject *obj, Option_t *opt)
+{
+   // Add object at the beginning of the list and also store option.
+   // Storing an option is useful when one wants to change the behaviour
+   // of an object a little without having to create a complete new
+   // copy of the object. This feature is used, for example, by the Draw()
+   // method. It allows the same object to be drawn in different ways.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddFirst(obj, opt);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddLast(TObject *obj)
+{
+   // Add object at the end of the list.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddLast(obj);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddLast(TObject *obj, Option_t *opt)
+{
+   // Add object at the end of the list and also store option.
+   // Storing an option is useful when one wants to change the behaviour
+   // of an object a little without having to create a complete new
+   // copy of the object. This feature is used, for example, by the Draw()
+   // method. It allows the same object to be drawn in different ways.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddLast(obj, opt);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddAt(TObject *obj, Int_t idx)
+{
+   // Insert object at location idx in the list.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddAt(obj, idx);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddAfter(const TObject *after, TObject *obj)
+{
+   // Insert object after object after in the list.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddAfter(after, obj);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddAfter(TObjLink *after, TObject *obj)
+{
+   // Insert object after object after in the list.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddAfter(after, obj);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddBefore(const TObject *before, TObject *obj)
+{
+   // Insert object before object before in the list.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddBefore(before, obj);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::AddBefore(TObjLink *before, TObject *obj)
+{
+   // Insert object before object before in the list.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::AddBefore(before, obj);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::Clear(Option_t *option)
+{
+   // Remove all objects from the list. Does not delete the objects unless
+   // the THashList is the owner (set via SetOwner()).
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::Clear(option);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::Delete(Option_t *option /* ="" */)
+{
+   // Delete all TDataMember object files.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::Delete(option);
+}
+
+//______________________________________________________________________________
+TObject *TListOfEnumsWithLock::FindObject(const char *name) const
+{
+   // Specialize FindObject to do search for the
+   // a enum just by name or create it if its not already in the list
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TObject *result = TListOfEnums::FindObject(name);
+   if (!result) {
+
+
+      TInterpreter::DeclId_t decl;
+      if (GetClass()) decl = gInterpreter->GetEnum(GetClass(), name);
+      else        decl = gInterpreter->GetEnum(0, name);
+      if (decl) result = const_cast<TListOfEnumsWithLock *>(this)->Get(decl, name);
+   }
+   return result;
+}
+
+
+//______________________________________________________________________________
+TObject* TListOfEnumsWithLock::FindObject(const TObject* obj) const
+{
+    R__LOCKGUARD(gInterpreterMutex);
+    return TListOfEnums::FindObject(obj);
+}
+
+//______________________________________________________________________________
+void TListOfEnumsWithLock::RecursiveRemove(TObject *obj)
+{
+   // Remove object from this collection and recursively remove the object
+   // from all other objects (and collections).
+   // This function overrides TCollection::RecursiveRemove that calls
+   // the Remove function. THashList::Remove cannot be called because
+   // it uses the hash value of the hash table. This hash value
+   // is not available anymore when RecursiveRemove is called from
+   // the TObject destructor.
+
+   if (!obj) return;
+
+   R__LOCKGUARD(gInterpreterMutex);
+   TListOfEnums::RecursiveRemove(obj);
+}
+
+//______________________________________________________________________________
+TObject *TListOfEnumsWithLock::Remove(TObject *obj)
+{
+   // Remove object from the list.
+
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::Remove(obj);
+}
+
+//______________________________________________________________________________
+TObject *TListOfEnumsWithLock::Remove(TObjLink *lnk)
+{
+   // Remove object via its objlink from the list.
+
+   if (!lnk) return 0;
+
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::Remove(lnk);
+}
+
+//______________________________________________________________________________
+TIterator* TListOfEnumsWithLock::MakeIterator(Bool_t dir ) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return new TListOfEnumsWithLockIter(this,dir);
+}
+
+//______________________________________________________________________________
+TObject* TListOfEnumsWithLock::At(Int_t idx) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::At(idx);
+}
+
+//______________________________________________________________________________
+TObject* TListOfEnumsWithLock::After(const TObject *obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::After(obj);
+}
+
+//______________________________________________________________________________
+TObject* TListOfEnumsWithLock::Before(const TObject *obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::Before(obj);
+}
+
+//______________________________________________________________________________
+TObject* TListOfEnumsWithLock::First() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::First();
+}
+
+//______________________________________________________________________________
+TObjLink* TListOfEnumsWithLock::FirstLink() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::FirstLink();
+}
+
+//______________________________________________________________________________
+TObject** TListOfEnumsWithLock::GetObjectRef(const TObject *obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::GetObjectRef(obj);
+}
+
+//______________________________________________________________________________
+TObject* TListOfEnumsWithLock::Last() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::Last();
+}
+
+//______________________________________________________________________________
+TObjLink* TListOfEnumsWithLock::LastLink() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::LastLink();
+}
+
+
+//______________________________________________________________________________
+Int_t TListOfEnumsWithLock::GetLast() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::GetLast();
+}
+
+//______________________________________________________________________________
+Int_t TListOfEnumsWithLock::IndexOf(const TObject *obj) const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::IndexOf(obj);
+}
+
+
+//______________________________________________________________________________
+Int_t TListOfEnumsWithLock::GetSize() const
+{
+   R__LOCKGUARD(gInterpreterMutex);
+   return TListOfEnums::GetSize();
+}
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TListOfEnumsWithLockIter                                                 //
+//                                                                      //
+// Iterator for TListOfEnumsWithLock.                                       //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+ClassImp(TListOfEnumsWithLockIter)
+
+//______________________________________________________________________________
+TListOfEnumsWithLockIter::TListOfEnumsWithLockIter(const TListOfEnumsWithLock *l, Bool_t dir ):
+  TListIter(l,dir) {}
+
+//______________________________________________________________________________
+TObject *TListOfEnumsWithLockIter::Next()
+{
+  R__LOCKGUARD(gInterpreterMutex);
+  return TListIter::Next();
+}


### PR DESCRIPTION
This extends the previous work on enum thread-safety to encompass
all the ways the enums can be scoped.