### PR TITLE
Quiet unnecessary warning from plugin manager.

### DIFF
--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -169,7 +169,7 @@ public:
    template <typename... T> Long_t ExecPlugin(int nargs, const T&... params)
    {
       // For backward compatibility.
-      if (gDebug > 1) {
+      if ((gDebug > 1) && (nargs != (int)sizeof...(params))) {
          Warning("ExecPlugin","Announced number of args different from the real number of argument passed %d vs %lu",
                  nargs, (unsigned long)sizeof...(params) );
       }


### PR DESCRIPTION
Only print a warning if there's actually a difference in the number of arguments.