### PR TITLE
gcc49 build on osx fix linker assertion

### DIFF
--- a/interpreter/llvm/Module.mk
+++ b/interpreter/llvm/Module.mk
@@ -125,7 +125,7 @@ $(LLVMDEPO): $(LLVMDEPS)
 		if [ $(ARCH) = "macosx64" ]; then \
 			LLVM_CFLAGS="-m64"; \
 		fi; \
-		if [ $(ARCH) = "macosx64" && x$$(GCC_MAJOR) != "x" ]; then \
+		if [ $(ARCH) = "macosx64" && "x$$(GCC_MAJOR)" != "x" ]; then \
 			LLVM_CFLAGS="-m64 -fno-omit-frame-pointer"; \
 		fi; \
 		if [ $(ARCH) = "iossim" ]; then \

--- a/interpreter/llvm/Module.mk
+++ b/interpreter/llvm/Module.mk
@@ -125,6 +125,9 @@ $(LLVMDEPO): $(LLVMDEPS)
 		if [ $(ARCH) = "macosx64" ]; then \
 			LLVM_CFLAGS="-m64"; \
 		fi; \
+		if [ $(ARCH) = "macosx64" && x$(GCC_MAJOR) != "x" ]; then \
+			LLVM_CFLAGS="-m64 -fno-omit-frame-pointer"; \
+		fi; \
 		if [ $(ARCH) = "iossim" ]; then \
 			LLVM_CFLAGS="-arch i386 -isysroot $(IOSSDK) -miphoneos-version-min=$(IOSVERS)"; \
 			LLVM_HOST="--host=i386-apple-darwin"; \

--- a/interpreter/llvm/Module.mk
+++ b/interpreter/llvm/Module.mk
@@ -125,7 +125,7 @@ $(LLVMDEPO): $(LLVMDEPS)
 		if [ $(ARCH) = "macosx64" ]; then \
 			LLVM_CFLAGS="-m64"; \
 		fi; \
-		if [ $(ARCH) = "macosx64" && x$(GCC_MAJOR) != "x" ]; then \
+		if [ $(ARCH) = "macosx64" && x$$(GCC_MAJOR) != "x" ]; then \
 			LLVM_CFLAGS="-m64 -fno-omit-frame-pointer"; \
 		fi; \
 		if [ $(ARCH) = "iossim" ]; then \


### PR DESCRIPTION
When building with gcc49 on osx a linker assertion happens when linking interpreter module. Trial and error reveal that setting -O0 removes the linker assertion. Dan Riley found that adding the flag -fno-omit-frame-pointer also removed the linker assertion without removing other optimizations.