### PR TITLE
 gcc49 build on osx fix linker assertion #64 resubmit

### DIFF
--- a/interpreter/llvm/Module.mk
+++ b/interpreter/llvm/Module.mk
@@ -123,10 +123,10 @@ $(LLVMDEPO): $(LLVMDEPS)
 			LLVM_CFLAGS="-m32"; \
 		fi; \
 		if [ $(ARCH) = "macosx64" ]; then \
-			LLVM_CFLAGS="-m64"; \
-		fi; \
-		if [ $(ARCH) = "macosx64" && x$(GCC_MAJOR) != "x" ]; then \
+         LLVM_CFLAGS="-m64"; \
+         if [ x$(GCC_MAJOR) != "x" ]; then \
 			LLVM_CFLAGS="-m64 -fno-omit-frame-pointer"; \
+         fi;
 		fi; \
 		if [ $(ARCH) = "iossim" ]; then \
 			LLVM_CFLAGS="-arch i386 -isysroot $(IOSSDK) -miphoneos-version-min=$(IOSVERS)"; \

--- a/interpreter/llvm/Module.mk
+++ b/interpreter/llvm/Module.mk
@@ -125,6 +125,9 @@ $(LLVMDEPO): $(LLVMDEPS)
 		if [ $(ARCH) = "macosx64" ]; then \
 			LLVM_CFLAGS="-m64"; \
 		fi; \
+		if [ $(ARCH) = "macosx64" && x$(GCC_MAJOR) != "x" ]; then \
+			LLVM_CFLAGS="-m64 -fno-omit-frame-pointer"; \
+		fi; \
 		if [ $(ARCH) = "iossim" ]; then \
 			LLVM_CFLAGS="-arch i386 -isysroot $(IOSSDK) -miphoneos-version-min=$(IOSVERS)"; \
 			LLVM_HOST="--host=i386-apple-darwin"; \

--- a/interpreter/llvm/Module.mk
+++ b/interpreter/llvm/Module.mk
@@ -123,10 +123,10 @@ $(LLVMDEPO): $(LLVMDEPS)
 			LLVM_CFLAGS="-m32"; \
 		fi; \
 		if [ $(ARCH) = "macosx64" ]; then \
-         LLVM_CFLAGS="-m64"; \
-         if [ x$(GCC_MAJOR) != "x" ]; then \
-			LLVM_CFLAGS="-m64 -fno-omit-frame-pointer"; \
-         fi;
+        		LLVM_CFLAGS="-m64"; \
+         		if [ x$(GCC_MAJOR) != "x" ]; then \
+				LLVM_CFLAGS="-m64 -fno-omit-frame-pointer"; \
+         		fi; \
 		fi; \
 		if [ $(ARCH) = "iossim" ]; then \
 			LLVM_CFLAGS="-arch i386 -isysroot $(IOSSDK) -miphoneos-version-min=$(IOSVERS)"; \

--- a/interpreter/llvm/Module.mk
+++ b/interpreter/llvm/Module.mk
@@ -100,6 +100,12 @@ $(LLVMLIB): $(LLVMDEPO) $(FORCELLVMTARGET)
 $(LLVMGOODO): $(LLVMGOODS) $(LLVMLIB)
 		@cp $(LLVMGOODS) $(LLVMGOODO)
 
+ifeq ($(CXX14),yes)
+LLVM_CXX_VERSION=--enable-cxx1y
+else
+LLVM_CXX_VERSION=--enable-cxx11
+endif
+
 $(LLVMDEPO): $(LLVMDEPS)
 		$(MAKEDIR)
 		@(LLVMCC="$(CC)" && \
@@ -120,13 +126,13 @@ $(LLVMDEPO): $(LLVMDEPS)
 			LLVM_CFLAGS="-m64"; \
 		fi; \
 		if [ $(ARCH) = "macosx" ]; then \
-			LLVM_CFLAGS="-m32"; \
+			LLVM_CFLAGS="-m32 -Wno-unused-private-field"; \
 		fi; \
 		if [ $(ARCH) = "macosx64" ]; then \
-        		LLVM_CFLAGS="-m64"; \
-         		if [ x$(GCC_MAJOR) != "x" ]; then \
-				LLVM_CFLAGS="-m64 -fno-omit-frame-pointer"; \
-         		fi; \
+			LLVM_CFLAGS="-m64 -Wno-unused-private-field"; \
+		fi; \
+		if [ $(ARCH) = "macosx64" -a x$(GCC_MAJOR) != "x" ]; then \
+			LLVM_CFLAGS="$$LLVM_CFLAGS -fno-omit-frame-pointer"; \
 		fi; \
 		if [ $(ARCH) = "iossim" ]; then \
 			LLVM_CFLAGS="-arch i386 -isysroot $(IOSSDK) -miphoneos-version-min=$(IOSVERS)"; \
@@ -167,7 +173,7 @@ $(LLVMDEPO): $(LLVMDEPS)
 		echo "*** Configuring LLVM in $(dir $@) ..."; \
 		mkdir -p $(dir $@) && \
 		cd $(dir $@)  && \
-		GNUMAKE=$(MAKE) $(LLVMDIRS)/configure --enable-cxx11 \
+		GNUMAKE=$(MAKE) $(LLVMDIRS)/configure $(LLVM_CXX_VERSION) \
 		$$LLVM_HOST \
 		$$LLVM_TARGET \
 		$$LLVM_BUILD \


### PR DESCRIPTION
When building with gcc49 on osx a linker assertion happens when linking interpreter module. Trial and error reveal that setting -O0 removes the linker assertion. Dan Riley found that adding the flag -fno-omit-frame-pointer also removed the linker assertion without removing other optimizations.