### PR TITLE
interpreter/llvm/CMakelists.txt: add -fno-omit-frame-pointer for gcc build on osx

### DIFF
--- a/interpreter/llvm/src/CMakeLists.txt
+++ b/interpreter/llvm/src/CMakeLists.txt
@@ -535,6 +535,11 @@ if( ${CMAKE_SYSTEM_NAME} MATCHES SunOS )
    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include llvm/Support/Solaris.h")
 endif( ${CMAKE_SYSTEM_NAME} MATCHES SunOS )
 
+
+if( ${CMAKE_SYSTEM_NAME} MATCHES Darwin AND ${CMAKE_CXX_COMPILER_ID} MATCHES GNU )
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
+endif( ${CMAKE_SYSTEM_NAME} MATCHES Darwin )
+
 # Make sure we don't get -rdynamic in every binary. For those that need it,
 # use set_target_properties(target PROPERTIES ENABLE_EXPORTS 1)
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")


### PR DESCRIPTION
This is a workaround for the linker assert when  building with gcc on osx. 