### PR TITLE
Shrink buffers when requested.

### DIFF
--- a/core/base/src/TBuffer.cxx
+++ b/core/base/src/TBuffer.cxx
@@ -201,7 +201,7 @@ void TBuffer::SetBuffer(void *buf, UInt_t newsiz, Bool_t adopt, ReAllocCharFun_t
 void TBuffer::Expand(Int_t newsize, Bool_t copy)
 {
    Int_t l  = Length();
-   if ( l > newsize ) {
+   if ( (l > newsize) && copy ) {
       newsize = l;
    }
    if ( (fMode&kWrite)!=0 ) {


### PR DESCRIPTION
Previous fixes to TBuffer::Expand broke its ability to shrink when data is not being copied (essential for keeping TBranches small).