### PR TITLE
Fix unused variable warning.

### DIFF
--- a/net/alien/src/TAlienCollection.cxx
+++ b/net/alien/src/TAlienCollection.cxx
@@ -1329,9 +1329,7 @@ Bool_t TAlienCollection::ExportXML(TFile * exportfile, Bool_t selected,
    filegroups->Reset();
    UInt_t groupcnt = 0;
    while ((nextgroup = (TMap *) filegroups->Next())) {
-      Bool_t isonline;
       Bool_t isselected;
-      isonline = kTRUE;
       isselected = kFALSE;
       TMap *attributes;
       TIterator *nextfile = nextgroup->MakeIterator();
@@ -1344,9 +1342,6 @@ Bool_t TAlienCollection::ExportXML(TFile * exportfile, Bool_t selected,
                isselected = kTRUE;
             }
 
-            if (!IsOnline(attributes->GetName())) {
-               isonline = kFALSE;
-            }
          }
       }
       if ((!selected) || isselected) {


### PR DESCRIPTION
This appears both on master and in the v5-34-XX branch. Can it be cleaned up?