### PR TITLE
msvc specific link command

### DIFF
--- a/bindings/pyroot/CMakeLists.txt
+++ b/bindings/pyroot/CMakeLists.txt
@@ -20,7 +20,7 @@ if(WIN32)
 endif()
 ROOT_LINKER_LIBRARY(PyROOT *.cxx G__PyROOT.cxx LIBRARIES Core Net Tree MathCore Rint ${PYTHON_LIBRARIES})
 
-if(WIN32)
+if(MSVC)
   add_custom_command(TARGET PyROOT POST_BUILD
                      COMMAND link -dll -nologo -IGNORE:4001 -machine:ix86 -export:initlibPyROOT
                     $<TARGET_LINKER_FILE:PyROOT> -nodefaultlib kernel32.lib msvcrt.lib


### PR DESCRIPTION
these are specific link options to be used only on a msvc host, won't work for a WIN32 mingw target for example

what does it do ? it seems it relinks the PyROOT library, with different options maybe ? isn't it something that could be achieved with cmake in a more generic way, by editing properties or flags ? also it seems its specific to arch ix86