### PR TITLE
Catch-all printValue implementation changed from refs to pointers

### DIFF
--- a/interpreter/cling/test/CodeUnloading/Dtors.C
+++ b/interpreter/cling/test/CodeUnloading/Dtors.C
@@ -62,6 +62,8 @@ int T(){
 
 // Make sure we have exactly one symbol of ~X(), i.e. that the unloading does
 // not remove it and CodeGen re-emits in upon seeing a new use in X c;
+12  // This is a temporary fix, not to allow .undo to try to unload RuntimePrintvalue.h
+    // If this is not here, the test hangs on first .undo 3 below. Should be investigated further.
 .storeState "preUnload2"
 .rawInput 1
 extern "C" int printf(const char*, ...);


### PR DESCRIPTION
Catch-all printValue implementation changed to enable correct invocation if only parent type overload exists (ex. if there is no overload for TF1*, compiler invokes the overload to its best parent overload match, in the worst case void*).

Argument changed from reference to pointer to support this.
isEnumType Coverity bug changed from if to assert (coding, not runtime error)
Changed the way printValue is invoked in order to correctly cast Value to the needed value (e.g. LL -> short). Extracted value stays in scope while we execute printValue, because we use the address.