### PR TITLE
Root 7457: Segmentation fault when embedding Type 1 fonts

### DIFF
--- a/graf2d/mathtext/src/fontembedps.cxx
+++ b/graf2d/mathtext/src/fontembedps.cxx
@@ -243,18 +243,18 @@ namespace mathtext {
          struct pfb_segment_header_s segment_header;
          size_t offset = 0;
 
-         segment_header.type = 0;
+         // The two char elements of struct
+         // pfb_segment_header_s are most likely aligned to
+         // larger than 1 byte boundaries, so copy all the
+         // elements individually
+         segment_header.always_128 = font_data[offset];
+         segment_header.type = font_data[offset + 1];
+
          while (segment_header.type != TYPE_EOF) {
-            // The two char elements of struct
-            // pfb_segment_header_s are most likely aligned to
-            // larger than 1 byte boundaries, so copy all the
-            // elements individually
-            segment_header.always_128 = font_data[offset];
-            segment_header.type = font_data[offset + 1];
             memcpy(&segment_header.length, &font_data[offset + 2],
                    sizeof(unsigned int));
             offset += sizeof(unsigned int) + 2;
-#ifdef LITTLE_ENDIAN
+#ifndef LITTLE_ENDIAN
             segment_header.length =
             bswap_32(segment_header.length);
 #endif // LITTLE_ENDIAN
@@ -289,6 +289,9 @@ namespace mathtext {
             }
 
             delete [] buffer;
+
+            segment_header.always_128 = font_data[offset];
+            segment_header.type = font_data[offset + 1];
          }
 
          return ret;

--- a/graf2d/mathtext/src/fontembedps.cxx
+++ b/graf2d/mathtext/src/fontembedps.cxx
@@ -30,14 +30,14 @@
 #ifndef LITTLE_ENDIAN
 #define LITTLE_ENDIAN 1
 #endif // LITTLE_ENDIAN
-#include "Byteswap.h"
-#define bswap_16(x)   Rbswap_16((x))
-#define bswap_32(x)   Rbswap_32((x))
 #else // R__BYTESWAP
 #ifdef LITTLE_ENDIAN
 #undef LITTLE_ENDIAN
 #endif // LITTLE_ENDIAN
 #endif // R__BYTESWAP
+#include "Byteswap.h"
+#define bswap_16(x)   Rbswap_16((x))
+#define bswap_32(x)   Rbswap_32((x))
 
 // References:
 //


### PR DESCRIPTION
This is a pull request based on the patches in https://sft.its.cern.ch/jira/browse/ROOT-7457

There are two problem with the code. Looking at a hexdump of a Type 1 font:
```
00000000 80 01 fb 15 00 00 25 21 50 53 2d 41 64 6f 62 65 |......%!PS-Adobe|
00000010 46 6f 6e 74 2d 31 2e 30 3a 20 53 74 61 6e 64 61 |Font-1.0: Standa|
[ ... ]
00008390 30 30 30 30 30 30 30 30 30 30 30 30 30 30 0d 63 |00000000000000.c|
000083a0 6c 65 61 72 74 6f 6d 61 72 6b 0a 80 03 |leartomark...|
```
The code currently reads beyond the 80 03 at the end of the file by trying to determing the length of the following block - but an end of file block does not have a length, the file ends right after the end of file block tag 08 03.

The length is in little endian format - as can be seen in the beginning of the file. The ascii block tag 80 01 is followed by fb 15 00 00 which is little endian for 000015fb. So it is big endian architectures that needs to do a byte swap, not little endian ones as in the current code.

The first attached patch addresses these issues. The second patch implements returning the fontname for Type 1 embedding.
