### PR TITLE
TClass::GetCheckSum fix for returned arugment

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5924,12 +5924,13 @@ UInt_t TClass::GetCheckSum(ECheckSum code, Bool_t &isvalid) const
    //    if (fCheckSum && code == kCurrentCheckSum) return fCheckSum;
    // However save a little bit of barier time by calling load()
    // only once.
+
+   isvalid = kTRUE;
+
    UInt_t currentChecksum = fCheckSum.load();
    if (currentChecksum && code == kCurrentCheckSum) return currentChecksum;
 
    R__LOCKGUARD(gInterpreterMutex);
-
-   isvalid = kTRUE;
 
    // kCurrentCheckSum (0) is the default parameter value and should be kept
    // for backward compatibility, too be able to use the inequality checks,


### PR DESCRIPTION
If the GetCheckSum value was already cached then the argument passed
to the function was not set. This now properly sets the value.