### PR TITLE
Reimplement signal handler to avoid async-unsafe functions

### DIFF
--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -38,10 +38,22 @@ int StackTraceExec(void *);
 
 typedef void (*SigHandler_t)(ESignals);
 
+struct TStackTraceHelper {
+   static const int             stringLength = 255;
+   char                         shellExec[stringLength];
+   char                         pidString[stringLength];
+   char                         pidNum[stringLength];
+   int                          parentToChild[2];
+   int                          childToParent[2];
+   std::unique_ptr<std::thread> helperThread;
+};
 
 class TUnixSystem : public TSystem {
 
    friend int     StackTraceExec(void *);
+
+private:
+   static struct TStackTraceHelper fStackTraceHelper;
 
 protected:
    const char    *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE);
@@ -79,13 +91,6 @@ protected:
    static int          UnixSend(int sock, const void *buf, int len, int flag);
 
    // added helper static members for stacktrace
-   static const int                    fPidStringLength = 255;
-   static char                         fShellExec[];
-   static char                         fPidString[fPidStringLength];
-   static char                         fPidNum[11];
-   static int                          fParentToChild[2];
-   static int                          fChildToParent[2];
-   static std::unique_ptr<std::thread> fHelperThread;   
    static char *const                  kStackArgv[];
    static char *const *                GetStackArgv();
    static void                         StackTraceHelperThread();

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -80,7 +80,9 @@ protected:
 
    // added helper static members for stacktrace
    static const int                    fPidStringLength = 255;
+   static char                         fShellExec[];
    static char                         fPidString[fPidStringLength];
+   static char                         fPidNum[11];
    static int                          fParentToChild[2];
    static int                          fChildToParent[2];
    static std::unique_ptr<std::thread> fHelperThread;   

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -34,18 +34,14 @@
 #include <thread>
 #include <memory>
 
-namespace std {
-  class thread;
-}
-
-int global_stacktrace(void *);
+int StackTraceExec(void *);
 
 typedef void (*SigHandler_t)(ESignals);
 
 
 class TUnixSystem : public TSystem {
 
-   friend int global_stacktrace(void *);
+   friend int     StackTraceExec(void *);
 
 protected:
    const char    *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE);
@@ -83,15 +79,15 @@ protected:
    static int          UnixSend(int sock, const void *buf, int len, int flag);
 
    // added helper static members for stacktrace
-   static const int pidStringLength_ = 255;
-   static char pidString_[pidStringLength_];
-   static char * const pstackArgv_[];
-   static char *const *getPstackArgv();
-   static int          parentToChild_[2];
-   static int          childToParent_[2];
-   static std::unique_ptr<std::thread> helperThread_;   
-   static void         stacktraceHelperThread();
-   void         cachePidInfo();
+   static const int                    fPidStringLength = 255;
+   static char                         fPidString[fPidStringLength];
+   static int                          fParentToChild[2];
+   static int                          fChildToParent[2];
+   static std::unique_ptr<std::thread> fHelperThread;   
+   static char *const                  kStackArgv[];
+   static char *const *                GetStackArgv();
+   static void                         StackTraceHelperThread();
+   void                                CachePidInfo();
 
 public:
    TUnixSystem();
@@ -143,7 +139,7 @@ public:
    void              Abort(int code = 0);
    int               GetPid();
    void              StackTrace();
-   static void       stacktraceFromThread();
+   static void       StackTraceFromThread();
 
    //---- Directories ------------------------------------------
    int               MakeDirectory(const char *name);

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -38,22 +38,23 @@ int StackTraceExec(void *);
 
 typedef void (*SigHandler_t)(ESignals);
 
-struct TStackTraceHelper {
-   static const int             stringLength = 255;
-   char                         shellExec[stringLength];
-   char                         pidString[stringLength];
-   char                         pidNum[stringLength];
-   int                          parentToChild[2];
-   int                          childToParent[2];
-   std::unique_ptr<std::thread> helperThread;
-};
 
 class TUnixSystem : public TSystem {
 
    friend int     StackTraceExec(void *);
 
 private:
-   static struct TStackTraceHelper fStackTraceHelper;
+   struct StackTraceHelper_t {
+      static const int fStringLength = 255;
+      char             fShellExec[fStringLength];
+      char             fPidString[fStringLength];
+      char             fPidNum[fStringLength];
+      int              fParentToChild[2];
+      int              fChildToParent[2];
+      std::unique_ptr<std::thread> fHelperThread;
+   };
+
+   static StackTraceHelper_t fStackTraceHelper;
 
 protected:
    const char    *FindDynamicLibrary(TString &lib, Bool_t quiet = kFALSE);
@@ -91,10 +92,10 @@ protected:
    static int          UnixSend(int sock, const void *buf, int len, int flag);
 
    // added helper static members for stacktrace
-   static char *const                  kStackArgv[];
-   static char *const *                GetStackArgv();
-   static void                         StackTraceHelperThread();
-   void                                CachePidInfo();
+   static char *const  kStackArgv[];
+   static char *const *GetStackArgv();
+   static void         StackTraceHelperThread();
+   void                CachePidInfo();
 
 public:
    TUnixSystem();

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -653,10 +653,10 @@ TUnixSystem::~TUnixSystem()
 
 std::unique_ptr<std::thread> TUnixSystem::fHelperThread;
 
-static char shellExec[]                                     = "/bin/sh";
+char TUnixSystem::fShellExec[] = "/bin/sh";
 char TUnixSystem::fPidString[TUnixSystem::fPidStringLength] = {};
-static char pidNum[11]                                      = {}; //--- The largest PID number could be converted to 10 characters.
-char * const TUnixSystem::kStackArgv[]                      = {shellExec, TUnixSystem::fPidString, pidNum, nullptr};
+char TUnixSystem::fPidNum[11]                               = {}; //--- The largest PID number could be converted to 10 characters.
+char * const TUnixSystem::kStackArgv[]                      = {TUnixSystem::fShellExec, TUnixSystem::fPidString, TUnixSystem::fPidNum, nullptr};
 int TUnixSystem::fParentToChild[2]                          = {-1, -1};
 int TUnixSystem::fChildToParent[2]                          = {-1, -1};
 
@@ -5374,7 +5374,7 @@ void TUnixSystem::CachePidInfo()
       return;
    }   
 #endif
-   if(sprintf(pidNum, "%d", GetPid()) >= fPidStringLength) {
+   if(sprintf(fPidNum, "%d", GetPid()) >= fPidStringLength) {
       SignalSafeErrWrite("Unable to pre-allocate process id information");
       return;
    }

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -568,11 +568,67 @@ TUnixSystem::~TUnixSystem()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialize Unix system interface.
+extern "C"
+{
+    static int full_write(int fd, const char *text)
+    {
+      const char *buffer = text;
+      size_t count = strlen(text);
+      ssize_t written = 0;
+      while (count)
+      {
+        written = write(fd, buffer, count);
+        if (written == -1) 
+        {
+          if (errno == EINTR) {continue;}
+          else {return -errno;}
+        }
+        count -= written;
+        buffer += written;
+      }
+      return 0;
+    }
+
+    static int full_read(int fd, char *inbuf, size_t len)
+    {
+      char *buf = inbuf;
+      size_t count = len;
+      ssize_t complete = 0;
+      while (count)
+      {
+        complete = read(fd, buf, count);
+        if (complete == -1)
+        {
+          if (errno == EINTR) {continue;}
+          else {return -errno;}
+        }
+        count -= complete;
+        buf += complete;
+      }
+      return 0;
+    }
+
+    static int full_cerr_write(const char *text)
+    {
+      return full_write(2, text);
+    }
+
+}
+
+static char pshellExec[8] = "/bin/sh";
+char TUnixSystem::pidString_[TUnixSystem::pidStringLength_] = {};
+static char pidNum[11] = {}; //--- The largest PID number could be converted to 10 characters.
+char * const TUnixSystem::pstackArgv_[] = {pshellExec, TUnixSystem::pidString_, pidNum, nullptr};
+int TUnixSystem::parentToChild_[2] = {-1, -1};
+int TUnixSystem::childToParent_[2] = {-1, -1};
+std::unique_ptr<std::thread> TUnixSystem::helperThread_;
 
 Bool_t TUnixSystem::Init()
 {
    if (TSystem::Init())
       return kTRUE;
+
+   cachePidInfo();
 
    fReadmask   = new TFdSet;
    fWritemask  = new TFdSet;
@@ -2154,10 +2210,8 @@ void TUnixSystem::StackTrace()
       }
       gdbscript += " ";
    }
-
    TString gdbmess = gEnv->GetValue("Root.StacktraceMessage", "");
    gdbmess = gdbmess.Strip();
-
    std::cout.flush();
    fflush(stdout);
 
@@ -2286,7 +2340,6 @@ void TUnixSystem::StackTrace()
          fprintf(f, "%s\n", gdbmess.Data());
          fclose(f);
       }
-
       // use gdb to get stack trace
 #ifdef R__MACOSX
       gdbscript += GetExePath();
@@ -3524,6 +3577,7 @@ static void sighandler(int sig)
 
 void TUnixSystem::DispatchSignals(ESignals sig)
 {
+   const char* signalname = "unknown"; 
    switch (sig) {
    case kSigAlarm:
       DispatchTimers(kFALSE);
@@ -3532,8 +3586,14 @@ void TUnixSystem::DispatchSignals(ESignals sig)
       CheckChilds();
       break;
    case kSigBus:
+      signalname = "bus error";
+      break;
    case kSigSegmentationViolation:
+      signalname = "segmentation violation";
+      break;
    case kSigIllegalInstruction:
+      signalname = "illegal instruction";
+      break;
    case kSigFloatingException:
       Break("TUnixSystem::DispatchSignals", "%s", UnixSigname(sig));
       StackTrace();
@@ -3556,6 +3616,20 @@ void TUnixSystem::DispatchSignals(ESignals sig)
       fSignals->Set(sig);
       fSigcnt++;
       break;
+   }
+
+   if ((sig == kSigIllegalInstruction) || (sig == kSigSegmentationViolation) || (sig == kSigBus))
+   {
+
+      full_cerr_write("\n\nA fatal system signal has occurred: ");
+      full_cerr_write(signalname);
+      full_cerr_write("\nThe following is the call stack containing the origin of the signal.\n"
+        "NOTE:The first few functions on the stack are artifacts of processing the signal and can be ignored\n\n");
+
+      TUnixSystem::stacktraceFromThread();
+
+      signal(sig, SIG_DFL);
+      raise(sig);
    }
 
    // check a-synchronous signals
@@ -5147,4 +5221,155 @@ int TUnixSystem::GetProcInfo(ProcInfo_t *info) const
 #endif
 
    return 0;
+}
+
+static void stacktrace_fork();
+
+void TUnixSystem::stacktraceHelperThread()
+{
+      int toParent = childToParent_[1];
+      int fromParent = parentToChild_[0];
+      char buf[2]; buf[1] = '\0';
+      while(true)
+      {
+        int result = full_read(fromParent, buf, 1);
+        if (result < 0)
+        {
+          close(toParent);
+          full_cerr_write("\n\nTraceback helper thread failed to read from parent: ");
+          full_cerr_write(strerror(-result));
+          full_cerr_write("\n");
+          ::abort();
+        }
+        if (buf[0] == '1')
+        {
+          stacktrace_fork();
+          full_write(toParent, buf);
+        }
+        else if (buf[0] == '2')
+        {
+          close(toParent);
+          close(fromParent);
+          toParent = childToParent_[1];
+          fromParent = parentToChild_[0];
+        }
+        else if (buf[0] == '3')
+        {
+          break;
+        }
+        else
+        {
+          close(toParent);
+          full_cerr_write("\n\nTraceback helper thread got unknown command from parent: ");
+          full_cerr_write(buf);
+          full_cerr_write("\n");
+          ::abort();
+        }
+      }
+}
+
+void TUnixSystem::stacktraceFromThread()
+{
+      int result = full_write(parentToChild_[1], "1"); 
+      if (result < 0)
+      {
+        full_cerr_write("\n\nAttempt to request stacktrace failed: ");
+        full_cerr_write(strerror(-result));
+        full_cerr_write("\n");
+        return;
+      }
+      char buf[2]; buf[1] = '\0';
+      if ((result = full_read(childToParent_[0], buf, 1)) < 0)
+      {
+        full_cerr_write("\n\nWaiting for stacktrace completion failed: ");
+        full_cerr_write(strerror(-result));
+        full_cerr_write("\n");
+        return;
+      }
+
+}
+
+void stacktrace_fork()
+{
+      char child_stack[4*1024];
+      char *child_stack_ptr = child_stack + 4*1024;
+      int pid =
+#ifdef __linux__
+        clone(global_stacktrace, child_stack_ptr, CLONE_VM|CLONE_FS|SIGCHLD, nullptr);
+#else
+        fork();
+      if (child_stack_ptr) {} // Suppress 'unused variable' warning on non-Linux
+      if (pid == 0) {global_stacktrace(nullptr); ::abort();}
+#endif
+      if (pid == -1)
+      {
+        full_cerr_write("(Attempt to perform stack dump failed.)\n");
+      }
+      else
+      {
+        int status;
+        if (waitpid(pid, &status, 0) == -1)
+        {
+          full_cerr_write("(Failed to wait on stack dump output.)\n");
+        } else {}
+      }
+}
+
+int global_stacktrace(void * /*arg*/)
+{
+      char *const *argv = TUnixSystem::getPstackArgv();
+      execv("/bin/sh", argv);
+      ::abort();
+      return 1;
+}
+
+char *const *TUnixSystem::getPstackArgv() {
+   return pstackArgv_;
+}
+
+void TUnixSystem::cachePidInfo()
+{
+#ifdef ROOTETCDIR
+      if(sprintf(pidString_, "%s/gdb-backtrace.sh", ROOTETCDIR) >= pidStringLength_)
+      {
+        full_cerr_write("Unable to pre-allocate executable information");
+	exit(1);
+      }
+#else
+      if(sprintf(pidString_, "%s/etc/gdb-backtrace.sh", Getenv("ROOTSYS")) >= pidStringLength_)
+      {
+        full_cerr_write("Unable to pre-allocate executable information");
+	exit(1);
+      }
+#endif
+
+      if(sprintf(pidNum, "%d", getpid()) >= pidStringLength_)
+      {
+        full_cerr_write("Unable to pre-allocate process id information");
+	exit(1);
+      }
+
+      close(childToParent_[0]);
+      close(childToParent_[1]);
+      childToParent_[0] = -1; childToParent_[1] = -1;
+      close(parentToChild_[0]);
+      close(parentToChild_[1]);
+      parentToChild_[0] = -1; parentToChild_[1] = -1;
+
+      if (-1 == pipe2(childToParent_, O_CLOEXEC))
+      {
+        fprintf(stdout, "pipe childToParent failed\n");
+	exit(1);
+      }
+
+      if (-1 == pipe2(parentToChild_, O_CLOEXEC))
+      {
+        close(childToParent_[0]); close(childToParent_[1]);
+        childToParent_[0] = -1; childToParent_[1] = -1;
+        fprintf(stdout, "pipe parentToChild failed\n");
+	exit(1);
+      }
+
+      helperThread_.reset(new std::thread(stacktraceHelperThread));
+      helperThread_->detach();
 }


### PR DESCRIPTION
@bbockelm @pcanal This patch copies the code of signal handling in CMSSW. It avoids async-unsafe functions in signal handler functions. 

For reference, see the link https://github.com/bbockelm/cmssw/blob/stacktrace_handler_revisit/FWCore/Services/src/InitRootHandlers.cc

I tried this patch with some simple multi-thread test cases and it worked fine. Is there any complicated test cases I can run? I think this patch is not very ready to merge, but it achieved basic functions. Any criticisms are welcome.