### PR TITLE
TAttMarker: Added missing marker style names in class documentation

### DIFF
--- a/core/base/src/TAttMarker.cxx
+++ b/core/base/src/TAttMarker.cxx
@@ -100,9 +100,9 @@ accessed via a global name (third column).
        29                    full star            kFullStar
        30                    open star            kOpenStar
        31                    *
-       32                    open triangle down
-       33                    full diamond
-       34                    full cross
+       32                    open triangle down   kOpenTriangleDown
+       33                    full diamond         kFullDiamond
+       34                    full cross           kFullCross
 ~~~
 
 Begin_Macro(source)


### PR DESCRIPTION
It is a minor fix but I though it would be nice to have the complete list since
I always forget the style names for polymarkers and use this documentation as
a reference. May also save someone else's time by avoiding a lookup in the
header file.