### PR TITLE
Made function pointer held by TMinuitMinimize thread local

### DIFF
--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -271,10 +271,6 @@ private:
    ROOT::Minuit::EMinimizerType fType;
    TMinuit * fMinuit;
 
-   // need to have a static copy of the function
-   //NOTE: This is NOT thread safe.
-   static ROOT::Math::IMultiGenFunction * fgFunc;
-
    static TMinuit * fgMinuit;
 
    static bool fgUsed;  // flag to control if static instance has done minimization

--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -22,6 +22,8 @@
 
 #include "TMatrixDSym.h" // needed for inverting the matrix
 
+#include "ThreadLocalStorage.h"
+
 #include <iostream>
 #include <cassert>
 #include <algorithm>
@@ -41,7 +43,10 @@
 // initialize the static instances
 
 
-ROOT::Math::IMultiGenFunction * TMinuitMinimizer::fgFunc = 0;
+namespace {
+   TTHREAD_TLS(ROOT::Math::IMultiGenFunction*) fgFunc = 0;
+}
+
 TMinuit * TMinuitMinimizer::fgMinuit = 0;
 bool TMinuitMinimizer::fgUsed = false;
 bool TMinuitMinimizer::fgUseStaticMinuit = true;   // default case use static Minuit instance


### PR DESCRIPTION
In order to allow different histograms to be fit simultaneously
on different threads the function pointer passed to Minuit by
TMinuitMinimizer must be unique for thread thread.