### PR TITLE
add constructor for struct Environ

### DIFF
--- a/core/cont/inc/TCollectionProxyInfo.h
+++ b/core/cont/inc/TCollectionProxyInfo.h
@@ -233,6 +233,7 @@ namespace Detail {
       size_t              fSpace;
    };
    template <typename T> struct Environ : public EnvironBase {
+      Environ() : fIterator() {}
       typedef T           Iter_t;
       Iter_t              fIterator;
       T& iter() { return fIterator; }


### PR DESCRIPTION
required to suppress warning/error when compiling with -Werror=effc++