### PR TITLE
TS3WebFile - add support for session keys

### DIFF
--- a/net/net/inc/TS3HTTPRequest.h
+++ b/net/net/inc/TS3HTTPRequest.h
@@ -72,6 +72,7 @@ protected:
    TString MakeAuthPrefix() const;
    TString MakeHostHeader() const;
    TString MakeDateHeader() const;
+   TString MakeTokenHeader() const;
    TS3HTTPRequest& SetTimeStamp();
 
 public:
@@ -101,6 +102,8 @@ public:
    TS3HTTPRequest& SetSecretKey(const TString& secretKey);
    TS3HTTPRequest& SetAuthKeys(const TString& accessKey, const TString& secretKey);
    TS3HTTPRequest& SetAuthType(TS3HTTPRequest::EAuthType authType);
+
+   TString   fToken;
 
    ClassDef(TS3HTTPRequest, 0)  // Create generic HTTP request for Amazon S3 and Google Storage services
 };

--- a/net/net/inc/TS3WebFile.h
+++ b/net/net/inc/TS3WebFile.h
@@ -77,9 +77,9 @@ class TS3WebFile: public TWebFile {
 
 private:
    TS3WebFile();
-   Bool_t ParseOptions(Option_t* options, TString& accessKey, TString& secretKey);
-   Bool_t GetCredentialsFromEnv(const char* accessKeyEnv, const char* secretKeyEnv,
-                                TString& outAccessKey, TString& outSecretKey);
+   Bool_t ParseOptions(Option_t* options, TString& accessKey, TString& secretKey, TString& token);
+   Bool_t GetCredentialsFromEnv(const char* accessKeyEnv, const char* secretKeyEnv, const char* tokenEnv,
+                                TString& outAccessKey, TString& outSecretKey, TString &outToken);
 
 protected:
    // Super-class methods extended by this class

--- a/net/net/src/TS3HTTPRequest.cxx
+++ b/net/net/src/TS3HTTPRequest.cxx
@@ -116,6 +116,10 @@ TString TS3HTTPRequest::ComputeSignature(TS3HTTPRequest::EHTTPVerb httpVerb) con
       toSign += "x-goog-api-version:1\n"; // Lowercase, no spaces around ':'
    }
 
+   if (!fToken.IsNull()) {
+     toSign += "x-amz-security-token:" + fToken + "\n";
+   }
+
    toSign += "/" + fBucket + fObjectKey;
 
    unsigned char digest[SHA_DIGEST_LENGTH] = {0};
@@ -210,6 +214,18 @@ TString TS3HTTPRequest::MakeAuthPrefix() const
 }
 
 //______________________________________________________________________________
+TString TS3HTTPRequest::MakeTokenHeader() const
+{
+
+  if (fToken.IsNull())
+    return "";
+
+  return TString::Format("x-amz-security-token: %s",
+			 (const char*) fToken.Data());
+}
+
+
+//______________________________________________________________________________
 TString TS3HTTPRequest::MakeAuthHeader(TS3HTTPRequest::EHTTPVerb httpVerb) const
 {
    // Returns the authentication header for this HTTP request
@@ -236,6 +252,10 @@ TString TS3HTTPRequest::GetRequest(TS3HTTPRequest::EHTTPVerb httpVerb, Bool_t ap
       (const char*)MakeRequestLine(httpVerb),
       (const char*)MakeHostHeader(),
       (const char*)MakeDateHeader());
+   TString tokenHeader = MakeTokenHeader();
+   if (!tokenHeader.IsNull())
+     request += tokenHeader + "\r\n";
+
    TString authHeader = MakeAuthHeader(httpVerb);
    if (!authHeader.IsNull())
       request += authHeader + "\r\n";


### PR DESCRIPTION
Hi,

Amazon has this concept of short-lived credentials via the "Security Token Service" (https://aws.amazon.com/documentation/iam/). In addition to generating the usual access and secure keys, the STS also generates a session token that needs to be used. This adds support for this. 

I made fToken public instead of a do-nothing getter, but that's a trivial change if you prefer it the other way.

(Also I should ask Georgios and friends to add this to davix - I didn't see it from a cursory glance at the code.)