### PR TITLE
Fix stack corruption in RooVectorDataStore

### DIFF
--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -750,6 +750,7 @@ public:
   mutable Double_t  _curWgtErr ;   // Weight of current event
 
   RooVectorDataStore* _cache ; //! Optimization cache
+  std::vector<RooVectorDataStore::RealVector*> _cacheUpdateList ; //! Pointers to the optimization cache
   RooAbsArg* _cacheOwner ; //! Cache owner
 
   Bool_t _forcedUpdate ; //! Request for forced cache update 


### PR DESCRIPTION
This is a fix for ROOT-7121.

If a cache is updated in RooVectorDataStore and the cache has more than 1000 elements to be updated, an array on the stack will overrun and smash the stack. roofit will therefore crash.

Solution: RooVectorDataStore uses a std::vector instead of an array[1000] to hold the pointers to the cache elements.

Comments on the speed of the fix:
Using a std::vector placed on the stack (mimicking the original implementation), the fits would get slower. Therefore I added the vector as a member of RooVectorDataStore. This saves the time of constantly having to reallocate the vector.

I tested with my (private) workspace: The crash is fixed. Unfortunately, I cannot provide this workspace.
To give a more meaningful test for you guys, I ran all the roofit/roostats tutorials and diffed the logs to check if roofit gives the same results. The diffs are attached. Apart from out-of-order execution and time measurements, there is no difference.
From the time measurements you can also see that the fixed version is not slower.

[tutorials_roofit.diff.txt](https://github.com/root-mirror/root/files/56528/tutorials_roofit.diff.txt)
[tutorials_roostats.diff.txt](https://github.com/root-mirror/root/files/56529/tutorials_roostats.diff.txt)


