### PR TITLE
Add support for abi-tags (adapted from Fedora's patch)

### DIFF
--- a/interpreter/llvm/src/docs/ItaniumMangleAbiTags.rst
+++ b/interpreter/llvm/src/docs/ItaniumMangleAbiTags.rst
@@ -1,0 +1,90 @@
+========
+Abi Tags
+========
+
+Introduction
+============
+
+This text tries to describe gcc semantic for mangling "abi_tag" attributes
+described in https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Attributes.html
+
+There is no guarantee the following rules are correct, complete or make sense
+in any way as they were determined empirically by experiments with gcc5.
+
+Declaration
+===========
+
+Abi tags are declared in an abi_tag attribute and can be applied to a
+function, variable, class or inline namespace declaration. The attribute takes
+one or more strings (called tags); the order does not matter.
+
+See https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Attributes.html for
+details.
+
+Tags on an inline namespace are called "implicit tags", all other tags are
+"explicit tags".
+
+Mangling
+========
+
+All tags that are "active" on a <unqualified-name> are emitted after the
+<unqualified-name>, before <template-args> or <discriminator>, and are part of
+the same <substitution> the <unqualified-name> is.
+
+They are mangled as:
+
+    <abi-tags> ::= <abi-tag>*   # sort by name
+    <abi-tag> ::= B <tag source-name>
+
+Example:
+
+    __attribute__((abi_tag("test")))
+    void Func();
+
+    gets mangled as: _Z4FuncB4testv (prettified as `Func[abi:test]()`)
+
+Active tags
+===========
+
+A namespace has never any active tags; for types (class / struct / union /
+enum) the explicit tags are the active tags.
+
+For variables and functions the active tags are the explicit tags plus any
+"required tags" which are not in the "available tags" set:
+
+    derived-tags := (required-tags - available-tags)
+    active-tags := explicit-tags + derived-tags
+
+Required tags for a function
+============================
+
+If a function is used as a local scope for another name, and is part of
+another function as local scope, it doesn't have any required tags.
+
+If a function is used as a local scope for a guard variable name, it doesn't
+have any required tags.
+
+Otherwise the function requires any implicit or explicit tag used in the name
+for the return type.
+
+Required tags for a variable
+============================
+
+A variable requires any implicit or explicit tag used in its type.
+
+Available tags
+==============
+
+All tags used in the prefix and in the template arguments for a name are
+available; for functions also all  tags from the <bare-function-type> (which
+might include the return type for template functions) are available.
+
+For <local-name>s all active tags used in the local part (<function-
+encoding>) are available, but not implicit tags which were not active!
+
+Implicit and explicit tags used in the <unqualified-name> for a function (as
+in the type of a cast operator) are NOT available.
+
+Example: a cast operator to std::string (which is
+std::__cxx11::basic_string<...>) will use 'cxx11' as active tag, as it is
+required from the return type `std::string` but not available.

--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/Attr.td
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/Attr.td
@@ -144,6 +144,7 @@ class TypeArgument<string name, bit opt = 0> : Argument<name, opt>;
 class UnsignedArgument<string name, bit opt = 0> : Argument<name, opt>;
 class VariadicUnsignedArgument<string name> : Argument<name, 1>;
 class VariadicExprArgument<string name> : Argument<name, 1>;
+class VariadicStringArgument<string name> : Argument<name, 1>;
 
 // A version of the form major.minor[.subminor].
 class VersionArgument<string name, bit opt = 0> : Argument<name, opt>;
@@ -335,6 +336,14 @@ class IgnoredAttr : Attr {
 //
 // Attributes begin here
 //
+
+def AbiTag : Attr {
+  let Spellings = [GCC<"abi_tag">];
+  let Args = [VariadicStringArgument<"Tags">];
+  let Subjects = SubjectList<[Struct, Var, Function, Namespace], ErrorDiag,
+                             "ExpectedStructClassVariableFunctionMethodOrInlineNamespace">;
+  let Documentation = [Undocumented];
+}
 
 def AddressSpace : TypeAttr {
   let Spellings = [GNU<"address_space">];

--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2255,7 +2255,8 @@ def warn_attribute_wrong_decl_type : Warning<
   "Objective-C instance methods|init methods of interface or class extension declarations|"
   "variables, functions and classes|Objective-C protocols|"
   "functions and global variables|structs, unions, and typedefs|structs and typedefs|"
-  "interface or protocol declarations|kernel functions}1">,
+  "interface or protocol declarations|kernel functions|"
+  "structs, classes, variables, functions, methods and inline namespaces}1">,
   InGroup<IgnoredAttributes>;
 def err_attribute_wrong_decl_type : Error<warn_attribute_wrong_decl_type.Text>;
 def warn_type_attribute_wrong_type : Warning<
@@ -3922,6 +3923,12 @@ def err_definition_of_explicitly_defaulted_member : Error<
 def err_redefinition_extern_inline : Error<
   "redefinition of a 'extern inline' function %0 is not supported in "
   "%select{C99 mode|C++}1">;
+def err_attr_abi_tag_only_on_inline_namespace :
+  Error<"abi_tag attribute only allowed on inline namespaces">;
+def err_abi_tag_on_redeclaration :
+  Error<"cannot add abi_tag attribute in redeclaration">;
+def err_new_abi_tag_on_redeclaration :
+  Error<"abi_tag %0 missing in original declaration">;
 
 def note_deleted_dtor_no_operator_delete : Note<
   "virtual destructor requires an unambiguous, accessible 'operator delete'">;

--- a/interpreter/llvm/src/tools/clang/include/clang/Sema/AttributeList.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Sema/AttributeList.h
@@ -846,7 +846,8 @@ enum AttributeDeclKind {
   ExpectedStructOrUnionOrTypedef,
   ExpectedStructOrTypedef,
   ExpectedObjectiveCInterfaceOrProtocol,
-  ExpectedKernelFunction
+  ExpectedKernelFunction,
+  ExpectedStructClassVariableFunctionMethodOrInlineNamespace
 };
 
 }  // end namespace clang

--- a/interpreter/llvm/src/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/interpreter/llvm/src/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -79,6 +79,7 @@ static std::string ReadPCHRecord(StringRef type) {
     .Case("TypeSourceInfo *", "GetTypeSourceInfo(F, Record, Idx)")
     .Case("Expr *", "ReadExpr(F)")
     .Case("IdentifierInfo *", "GetIdentifierInfo(F, Record, Idx)")
+    .Case("std::string", "ReadString(Record, Idx)")
     .Default("Record[Idx++]");
 }
 
@@ -92,6 +93,7 @@ static std::string WritePCHRecord(StringRef type, StringRef name) {
     .Case("Expr *", "AddStmt(" + std::string(name) + ");\n")
     .Case("IdentifierInfo *", 
           "AddIdentifierRef(" + std::string(name) + ", Record);\n")
+    .Case("std::string", "AddString(" + std::string(name) + ", Record);\n")
     .Default("Record.push_back(" + std::string(name) + ");\n");
 }
 
@@ -986,6 +988,16 @@ namespace {
     }
   };
 
+  class VariadicStringArgument : public VariadicArgument {
+  public:
+    VariadicStringArgument(const Record &Arg, StringRef Attr)
+      : VariadicArgument(Arg, Attr, "std::string")
+    {}
+    void writeValueImpl(raw_ostream &OS) const override {
+      OS << "    OS << \"\\\"\" << Val << \"\\\"\";\n";
+    }
+  };
+
   class TypeArgument : public SimpleArgument {
   public:
     TypeArgument(const Record &Arg, StringRef Attr)
@@ -1047,6 +1059,8 @@ createArgument(const Record &Arg, StringRef Attr,
     Ptr = llvm::make_unique<SimpleArgument>(Arg, Attr, "unsigned");
   else if (ArgName == "VariadicUnsignedArgument")
     Ptr = llvm::make_unique<VariadicArgument>(Arg, Attr, "unsigned");
+  else if (ArgName == "VariadicStringArgument")
+    Ptr = llvm::make_unique<VariadicStringArgument>(Arg, Attr);
   else if (ArgName == "VariadicEnumArgument")
     Ptr = llvm::make_unique<VariadicEnumArgument>(Arg, Attr);
   else if (ArgName == "VariadicExprArgument")


### PR DESCRIPTION
https://sft.its.cern.ch/jira/browse/ROOT-7818
https://sft.its.cern.ch/jira/browse/ROOT-7721
https://sft.its.cern.ch/jira/browse/ROOT-7654
https://sft.its.cern.ch/jira/browse/ROOT-7319
https://sft.its.cern.ch/jira/browse/ROOT-7285
Possibly more...

Adapted from:
http://pkgs.fedoraproject.org/cgit/llvm.git/tree/0001-add-gcc-abi_tag-support.patch
