### PR TITLE
Vc: ifdef x86-specific code

### DIFF
--- a/math/vc/include/Vc/support.h
+++ b/math/vc/include/Vc/support.h
@@ -26,7 +26,7 @@
 
 #include <Vc/cpuid.h>
 
-#if defined(VC_GCC) && VC_GCC >= 0x40400
+#if defined(VC_GCC) && VC_GCC >= 0x40400 && (defined __x86__ || defined __x86_64__)
 #define VC_TARGET_NO_SIMD __attribute__((target("no-sse2,no-avx")))
 #else
 #define VC_TARGET_NO_SIMD

--- a/math/vc/src/cpuid.cpp
+++ b/math/vc/src/cpuid.cpp
@@ -20,6 +20,8 @@
 #include <Vc/cpuid.h>
 #include <Vc/global.h>
 
+#if defined __x86__ || defined __x86_64__
+
 namespace ROOT {
 namespace Vc
 {
@@ -619,5 +621,7 @@ void CpuId::interpret(uchar byte, bool *checkLeaf4)
 }
 } // namespace Vc
 } // namespace ROOT
+
+#endif  // __x86__ || __x86_64__
 
 // vim: sw=4 sts=4 et tw=100


### PR DESCRIPTION
The CPUID code is x86-specific, so compile it only for x86 targets.
Additionally, the Impl query must return false unconditionally for any SIMD
instruction set for non-x86.

Signed-off-by: Matthias Kretz <kretz@kde.org>