### PR TITLE
Unset Fortran compiler if user disables fortran.

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -9,6 +9,8 @@ if(fortran)
     set(CMAKE_Fortran_COMPILER CMAKE_Fortran_COMPILER-NOTFOUND)
   endif()
   enable_language(Fortran OPTIONAL)
+else()
+  set(CMAKE_Fortran_COMPILER CMAKE_Fortran_COMPILER-NOTFOUND)
 endif()
 
 #----Get the compiler file name (to ensure re-location)---------------------------------------------


### PR DESCRIPTION
If the user disables fortran but a fortran compiler is actually
present, then hist/CMakeLists.txt will still try to compile
hbook (which results in a failure).

This patch explicitly sets the fortran compiler to not found
in order to prevent this from occurring.