### PR TITLE
JupyROOT: fixed ROOT-R support for ROOTBooks

### DIFF
--- a/bindings/pyroot/JupyROOT/handlers.py
+++ b/bindings/pyroot/JupyROOT/handlers.py
@@ -10,6 +10,7 @@
 from ctypes import CDLL, c_char_p
 from threading import Thread
 from time import sleep as timeSleep
+from resource import setrlimit, RLIMIT_STACK, RLIM_INFINITY
 
 _lib = CDLL("libJupyROOT.so")
 
@@ -85,6 +86,7 @@ class Runner(object):
     '''
     def __init__(self, function):
         self.function = function
+        setrlimit(RLIMIT_STACK,(RLIM_INFINITY,RLIM_INFINITY))
         self.thread = None
 
     def Run(self, argument):


### PR DESCRIPTION
Hello!

ROOT-R is now supported with JupyROOT, the problem was a message from 
R "error c stack usage is too close to the limit".
It was fixed using module  resource from python to set unlimited stack size in multithread execution,
anyway the stack in  OS will be the limit. "see ulimit -s" for Gnu/Linux.

Best.
 