### PR TITLE
disable GREP_OPTIONS, this fixes ROOT-8056

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -436,7 +436,7 @@ namespace {
         "echo | LC_ALL=C " LLVM_CXX " -xc++ -E -v - 2>&1 >/dev/null "
         "| awk '/^#include </,/^End of search"
         "/{if (!/^#include </ && !/^End of search/){ print }}' "
-        "| grep -E \"(c|g)\\+\\+\"";
+        "| GREP_OPTIONS= grep -E \"(c|g)\\+\\+\"";
       if (FILE *pf = ::popen(CppInclQuery, "r")) {
 
         HostCXXI.push_back("-nostdinc++");


### PR DESCRIPTION
The patch which I suggested on https://sft.its.cern.ch/jira/browse/ROOT-8056.
If the user uses GREP_OPTIONS which add characters to the output of grep (colors, but also filenames or line numbers), root cannot be started anymore. Ideally users would prefer an alias for `grep` over `GREP_OPTIONS` but the crash can also be avoided on the root side.