### PR TITLE
adding in ability for rooteventselector to skim trees based on a selection string

### DIFF
--- a/README/README.SELECTOR
+++ b/README/README.SELECTOR
@@ -114,7 +114,7 @@ The Init() member function
 
 The Init() function is called when the selector needs to initialize
 a new tree or chain. Typically here the branch addresses of the tree
-will be set. It is normaly not necessary to make changes to the generated
+will be set. It is normally not necessary to make changes to the generated
 code, but the routine can be extended by the user if needed. Init() will
 be called many times when running with PROOF.
 

--- a/README/ReleaseNotes/v608/index.md
+++ b/README/ReleaseNotes/v608/index.md
@@ -32,7 +32,7 @@ The following people have contributed to this new version:
  Paul Russo, Fermilab,\
  Enric Tejedor Saavedra, CERN/SFT,\
  Liza Sakellari, CERN/SFT,\
- Manuel Tobias Schiller,\
+ Manuel Tobias Schiller, CERN/LHCb,\
  David Smith, CERN/IT,\
  Matevz Tadel, UCSD/CMS, Eve,\
  Vassil Vassilev, Fermilab/CMS,\

--- a/gui/gui/src/TGXYLayout.cxx
+++ b/gui/gui/src/TGXYLayout.cxx
@@ -72,7 +72,7 @@
 //    .                                                                 //
 // }                                                                    //
 //                                                                      //
-// Normaly there is one layout hint per widget. Therefore these         //
+// Normally there is one layout hint per widget. Therefore these        //
 // can be deleted like in the following example in the desctuctor       //
 // of the frame:                                                        //
 //                                                                      //

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -767,11 +767,14 @@ def _copyTreeSubset(sourceFile,sourcePathSplit,destFile,destPathSplit,firstEvent
             super(ROOT.TNtuple,smallTree).Fill()
         else:
             smallTree.Fill()
-    if isNtuple:
-        smallTree = super(ROOT.TNtuple,smallTree).CopyTree(selectionString)
+    if selectionString:
+        if isNtuple:
+            smallSkimmedTree = super(ROOT.TNtuple,smallTree).CopyTree(selectionString)
+        else:
+            smallSkimmedTree = smallTree.CopyTree(selectionString)
+        smallSkimmedTree.Write()
     else:
-        smallTree = smallTree.CopyTree(selectionString)
-    smallTree.Write()
+        smallTree.Write()
     return retcode
 
 def _copyTreeSubsets(fileName, pathSplitList, destFile, destPathSplit, first, last, selectionString):
@@ -789,7 +792,7 @@ def _copyTreeSubsets(fileName, pathSplitList, destFile, destPathSplit, first, la
     return retcode
 
 def rootEventselector(sourceList, destFileName, destPathSplit, \
-                      compress=None, recreate=False, first=0, last=-1, selectionString="1"):
+                      compress=None, recreate=False, first=0, last=-1, selectionString=""):
     # Check arguments
     if sourceList == [] or destFileName == "": return 1
     if recreate and destFileName in sourceList:

--- a/main/python/rooteventselector.py
+++ b/main/python/rooteventselector.py
@@ -43,7 +43,7 @@ def execute():
     parser.add_argument("--recreate", help=cmdLineUtils.RECREATE_HELP, action="store_true")
     parser.add_argument("-f","--first", type=int, default=0, help=FIRST_EVENT_HELP)
     parser.add_argument("-l","--last", type=int, default=-1, help=LAST_EVENT_HELP)
-    parser.add_argument("-s","--selection", default="1")
+    parser.add_argument("-s","--selection", default="")
 
     # Put arguments in shape
     sourceList, destFileName, destPathSplit, optDict = cmdLineUtils.getSourceDestListOptDict(parser)

--- a/test/periodic/XSReactionDlg.cxx
+++ b/test/periodic/XSReactionDlg.cxx
@@ -497,7 +497,7 @@ XSReactionDlg::~XSReactionDlg()
 void
 XSReactionDlg::InitColorCombo(TGComboBox *cb)
 {
-   // Normaly this should be filled with color entries!!!
+   // Normally this should be filled with color entries!!!
 
    cb->AddEntry("Black",0);
    cb->AddEntry("Red",1);

--- a/tree/treeplayer/src/TSelectorEntries.cxx
+++ b/tree/treeplayer/src/TSelectorEntries.cxx
@@ -116,7 +116,7 @@ Int_t TSelectorEntries::GetEntry(Long64_t entry, Int_t getall)
 /// The Init() function is called when the selector needs to initialize
 /// a new tree or chain. Typically here the branch addresses and branch
 /// pointers of the tree will be set.
-/// It is normaly not necessary to make changes to the generated
+/// It is normally not necessary to make changes to the generated
 /// code, but the routine can be extended by the user if needed.
 /// Init() will be called many times when running on PROOF
 /// (once per file to be processed).


### PR DESCRIPTION
Hi all,

I love the new command line utils included in the releases in root/main/python/.

However, I found the rooteventselector command to be lacking in some functionality, so I added the ability for it to skim based on a selection string (a la a TCut). I hope this is useful for others!

-Larry