### PR TITLE
RooStats::SPlot tutorial shape parameter constant-setting

### DIFF
--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -296,7 +296,6 @@ TMVA::Reader::~Reader( void )
 
 ////////////////////////////////////////////////////////////////////////////////
 /// default initialisation (no member variables)
-/// default initialisation (no member variables)
 
 void TMVA::Reader::Init( void )
 {

--- a/tutorials/roostats/rs301_splot.C
+++ b/tutorials/roostats/rs301_splot.C
@@ -213,10 +213,15 @@ void DoSPlot(RooWorkspace* ws){
 
   // The sPlot technique requires that we fix the parameters
   // of the model that are not yields after doing the fit.
-  RooRealVar* sigmaZ = ws->var("sigmaZ");
-  RooRealVar* qcdMassDecayConst = ws->var("qcdMassDecayConst");
-  sigmaZ->setConstant();
-  qcdMassDecayConst->setConstant();
+  //
+  // This *could* be done with the lines below, however this is taken care of
+  // by the RooStats::SPlot constructor (or more precisely the AddSWeight
+  // method).
+  //
+  //RooRealVar* sigmaZ = ws->var("sigmaZ");
+  //RooRealVar* qcdMassDecayConst = ws->var("qcdMassDecayConst");
+  //sigmaZ->setConstant();
+  //qcdMassDecayConst->setConstant();
 
 
   RooMsgService::instance().setSilentMode(true);


### PR DESCRIPTION
RooStats::SPlot already takes care about setting shape parameters constant. It is not necessary to do this as a user. This should be demonstrated in the tutorial, especially it should be stated that the parameters are set constant already.