### PR TITLE
FindPostgreSQL.cmake: Add PATH_SUFFIX for searching.

### DIFF
--- a/cmake/modules/FindPostgreSQL.cmake
+++ b/cmake/modules/FindPostgreSQL.cmake
@@ -28,6 +28,9 @@ find_path(POSTGRESQL_INCLUDE_DIR libpq-fe.h
    "/usr/include/pgsql/server"
    "/usr/include/postgresql/server"
    "/usr/include/postgresql/*/server"
+  PATH_SUFFIXES
+    postgresql
+    include
 )
 
 find_library(POSTGRESQL_LIBRARY NAMES pq


### PR DESCRIPTION
This slightly changes lookup order: Namely, the system-folder "/usr/include/postgresql"
is now preferred over "/usr/include/" even if both container libpq-fe.h.
This finds the correct path on a standard Gentoo installation, where "/usr/include/postgresql"
is a symlink to the folder with all include-files for the user-selected postgresql-version,
while "/usr/include/libpq-fe.h" is a single symlink provided for backwards-compatibility.

Since ROOT uses also e.g. "pg_config.h", selecting "/usr/include/" over "/usr/include/postgresql"
leads to failure on Gentoo.

I hope this will not break any other existing setups but I don't see how it should. 
That should prevent any downstream-patching which Gentoo is doing right now for old-style configure once it has moved to cmake. 