### PR TITLE
TText: Fix missing initialization in copy constructor and TText::Copy.

### DIFF
--- a/graf2d/graf/src/TText.cxx
+++ b/graf2d/graf/src/TText.cxx
@@ -94,7 +94,7 @@ TText::~TText()
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor.
 
-TText::TText(const TText &text) : TNamed(text), TAttText(text), TAttBBox2D(text)
+TText::TText(const TText &text) : TNamed(text), TAttText(text), TAttBBox2D(text), fWcsTitle(NULL)
 {
    fX = 0.;
    fY = 0.;
@@ -110,13 +110,17 @@ void TText::Copy(TObject &obj) const
    ((TText&)obj).fY = fY;
    TNamed::Copy(obj);
    TAttText::Copy(((TText&)obj));
-   if (fWcsTitle != NULL) {
-      *reinterpret_cast<std::wstring *>(fWcsTitle) =
-         *reinterpret_cast<std::wstring *>(((TText&)obj).fWcsTitle);
+   if (((TText&)obj).fWcsTitle != NULL) {
+      if (fWcsTitle != NULL) {
+         *reinterpret_cast<std::wstring*>(&((TText&)obj).fWcsTitle) = *reinterpret_cast<const std::wstring*>(&fWcsTitle);
+      } else {
+        delete reinterpret_cast<std::wstring*>(&((TText&)obj).fWcsTitle);
+        ((TText&)obj).fWcsTitle = NULL;
+      }
    } else {
-      dynamic_cast<TText &>(obj).fWcsTitle =
-         new std::wstring(*reinterpret_cast<std::wstring *>(
-         dynamic_cast<TText &>(obj).fWcsTitle));
+      if (fWcsTitle != NULL) {
+         ((TText&)(obj)).fWcsTitle = new std::wstring(*reinterpret_cast<const std::wstring*>(fWcsTitle));
+      }
    }
 }
 


### PR DESCRIPTION
TText::Copy was broken in several ways:
- wchar-title was not copied to the given object, but from it.
- nullptr checks were missing.
The combination of both issues lead to all cases of TText::Copy to fail
(no matter if the wchar-name was set or not).

The corresponding JIRA ticket is:
https://sft.its.cern.ch/jira/browse/ROOT-8116