### PR TITLE
 Inline and access optimizations for TLorentzVector and TVector3

### DIFF
--- a/math/physics/inc/TLorentzVector.h
+++ b/math/physics/inc/TLorentzVector.h
@@ -64,7 +64,7 @@ public:
    TLorentzVector(const TLorentzVector & lorentzvector);
    // Copy constructor.
 
-   virtual ~TLorentzVector();
+   virtual ~TLorentzVector(){};
    // Destructor
 
    // inline operator TVector3 () const;
@@ -365,8 +365,8 @@ inline void TLorentzVector::GetXYZT(Float_t *carray) const{
    carray[3] = fE;
 }
 
-Double_t & TLorentzVector::operator [] (int i)       { return (*this)(i); }
-Double_t   TLorentzVector::operator [] (int i) const { return (*this)(i); }
+inline Double_t & TLorentzVector::operator [] (int i)       { return (*this)(i); }
+inline Double_t   TLorentzVector::operator [] (int i) const { return (*this)(i); }
 
 inline TLorentzVector &TLorentzVector::operator = (const TLorentzVector & q) {
    fP = q.Vect();
@@ -596,5 +596,60 @@ inline TLorentzVector operator * (Double_t a, const TLorentzVector & p) {
    return TLorentzVector(a*p.X(), a*p.Y(), a*p.Z(), a*p.T());
 }
 
+inline TLorentzVector::TLorentzVector()
+               : fP(), fE(0.0) {}
+
+inline TLorentzVector::TLorentzVector(Double_t x, Double_t y, Double_t z, Double_t t)
+               : fP(x,y,z), fE(t) {}
+
+inline TLorentzVector::TLorentzVector(const Double_t * x0)
+               : fP(x0), fE(x0[3]) {}
+
+inline TLorentzVector::TLorentzVector(const Float_t * x0)
+               : fP(x0), fE(x0[3]) {}
+
+inline TLorentzVector::TLorentzVector(const TVector3 & p, Double_t e)
+               : fP(p), fE(e) {}
+
+inline TLorentzVector::TLorentzVector(const TLorentzVector & p) : TObject(p)
+               , fP(p.Vect()), fE(p.T()) {}
+
+
+
+inline Double_t TLorentzVector::operator () (int i) const
+{
+   //dereferencing operator const
+   switch(i) {
+      case kX:
+	 return fP.X();
+      case kY:
+         return fP.Y();
+      case kZ:
+         return fP.Z();
+      case kT:
+         return fE;
+      default:
+         Error("operator()()", "bad index (%d) returning 0",i);
+   }
+   return 0.;
+}
+
+inline Double_t & TLorentzVector::operator () (int i)
+{
+   //dereferencing operator
+   switch(i) {
+      case kX:
+         return fP.fX;
+      case kY:
+         return fP.fY;
+      case kZ:
+         return fP.fZ;
+      case kT:
+         return fE;
+      default:
+         Error("operator()()", "bad index (%d) returning &fE",i);
+   }
+   return fE;
+}
 
 #endif

--- a/math/physics/inc/TVector3.h
+++ b/math/physics/inc/TVector3.h
@@ -20,6 +20,9 @@
 #ifndef ROOT_TMatrix
 #include "TMatrix.h"
 #endif
+#ifndef ROOT_TMath
+#include "TMath.h"
+#endif
 
 class TRotation;
 
@@ -42,7 +45,7 @@ public:
    TVector3(const TVector3 &);
    // The copy constructor.
 
-   virtual ~TVector3();
+   virtual ~TVector3() {};
    // Destructor
 
    Double_t operator () (int) const;
@@ -88,7 +91,7 @@ public:
    inline Double_t Mag2() const;
    // The magnitude squared (rho^2 in spherical coordinate system).
 
-   Double_t Mag() const;
+   Double_t Mag() const { return TMath::Sqrt(Mag2()); }
    // The magnitude (rho in spherical coordinate system).
 
    void SetPhi(Double_t);
@@ -192,8 +195,9 @@ private:
 
    ClassDef(TVector3,3) // A 3D physics vector
 
+   // make TLorentzVector a friend class
+   friend class TLorentzVector;
 };
-
 
 TVector3 operator + (const TVector3 &, const TVector3 &);
 // Addition of 3-vectors.
@@ -211,8 +215,8 @@ TVector3 operator * (Double_t a, const TVector3 &);
 TVector3 operator * (const TMatrix &, const TVector3 &);
 
 
-Double_t & TVector3::operator[] (int i)       { return operator()(i); }
-Double_t   TVector3::operator[] (int i) const { return operator()(i); }
+inline Double_t & TVector3::operator[] (int i)       { return operator()(i); }
+inline Double_t   TVector3::operator[] (int i) const { return operator()(i); }
 
 inline Double_t TVector3::x()  const { return fX; }
 inline Double_t TVector3::y()  const { return fY; }
@@ -246,6 +250,51 @@ inline void TVector3::GetXYZ(Float_t *carray) const {
    carray[2] = fZ;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Constructors
+inline TVector3::TVector3()
+: fX(0.0), fY(0.0), fZ(0.0) {}
+
+inline TVector3::TVector3(const TVector3 & p) : TObject(p),
+  fX(p.fX), fY(p.fY), fZ(p.fZ) {}
+
+inline TVector3::TVector3(Double_t xx, Double_t yy, Double_t zz)
+: fX(xx), fY(yy), fZ(zz) {}
+
+inline TVector3::TVector3(const Double_t * x0)
+: fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
+
+inline TVector3::TVector3(const Float_t * x0)
+: fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
+
+
+inline Double_t TVector3::operator () (int i) const {
+   switch(i) {
+      case 0:
+         return fX;
+      case 1:
+         return fY;
+      case 2:
+         return fZ;
+      default:
+         Error("operator()(i)", "bad index (%d) returning 0",i);
+   }
+   return 0.;
+}
+
+inline Double_t & TVector3::operator () (int i) {
+   switch(i) {
+      case 0:
+         return fX;
+      case 1:
+         return fY;
+      case 2:
+         return fZ;
+      default:
+         Error("operator()(i)", "bad index (%d) returning &fX",i);
+   }
+   return fX;
+}
 
 inline TVector3 & TVector3::operator = (const TVector3 & p) {
    fX = p.fX;
@@ -372,5 +421,6 @@ inline TVector2 TVector3::EtaPhiVector() const {
 inline TVector2 TVector3::XYvector() const {
    return TVector2(fX,fY);
 }
+
 
 #endif

--- a/math/physics/src/TLorentzVector.cxx
+++ b/math/physics/src/TLorentzVector.cxx
@@ -247,57 +247,6 @@ be used by the Transform() member function, the *= or
 
 ClassImp(TLorentzVector)
 
-TLorentzVector::TLorentzVector()
-               : fP(), fE(0.0) {}
-
-TLorentzVector::TLorentzVector(Double_t x, Double_t y, Double_t z, Double_t t)
-               : fP(x,y,z), fE(t) {}
-
-TLorentzVector::TLorentzVector(const Double_t * x0)
-               : fP(x0), fE(x0[3]) {}
-
-TLorentzVector::TLorentzVector(const Float_t * x0)
-               : fP(x0), fE(x0[3]) {}
-
-TLorentzVector::TLorentzVector(const TVector3 & p, Double_t e)
-               : fP(p), fE(e) {}
-
-TLorentzVector::TLorentzVector(const TLorentzVector & p) : TObject(p)
-               , fP(p.Vect()), fE(p.T()) {}
-
-TLorentzVector::~TLorentzVector()  {}
-
-Double_t TLorentzVector::operator () (int i) const
-{
-   //dereferencing operator const
-   switch(i) {
-      case kX:
-      case kY:
-      case kZ:
-         return fP(i);
-      case kT:
-         return fE;
-      default:
-         Error("operator()()", "bad index (%d) returning 0",i);
-   }
-   return 0.;
-}
-
-Double_t & TLorentzVector::operator () (int i)
-{
-   //dereferencing operator
-   switch(i) {
-      case kX:
-      case kY:
-      case kZ:
-         return fP(i);
-      case kT:
-         return fE;
-      default:
-         Error("operator()()", "bad index (%d) returning &fE",i);
-   }
-   return fE;
-}
 
 void TLorentzVector::Boost(Double_t bx, Double_t by, Double_t bz)
 {

--- a/math/physics/src/TVector3.cxx
+++ b/math/physics/src/TVector3.cxx
@@ -176,74 +176,6 @@ theta plane) to the (x,y,z) frame.
 
 ClassImp(TVector3)
 
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-TVector3::TVector3()
-: fX(0.0), fY(0.0), fZ(0.0) {}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-TVector3::TVector3(const TVector3 & p) : TObject(p),
-  fX(p.fX), fY(p.fY), fZ(p.fZ) {}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-TVector3::TVector3(Double_t xx, Double_t yy, Double_t zz)
-: fX(xx), fY(yy), fZ(zz) {}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-TVector3::TVector3(const Double_t * x0)
-: fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-TVector3::TVector3(const Float_t * x0)
-: fX(x0[0]), fY(x0[1]), fZ(x0[2]) {}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-TVector3::~TVector3() {}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Dereferencing operator const
-
-Double_t TVector3::operator () (int i) const {
-   switch(i) {
-      case 0:
-         return fX;
-      case 1:
-         return fY;
-      case 2:
-         return fZ;
-      default:
-         Error("operator()(i)", "bad index (%d) returning 0",i);
-   }
-   return 0.;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Dereferencing operator
-
-Double_t & TVector3::operator () (int i) {
-   switch(i) {
-      case 0:
-         return fX;
-      case 1:
-         return fY;
-      case 2:
-         return fZ;
-      default:
-         Error("operator()(i)", "bad index (%d) returning &fX",i);
-   }
-   return fX;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Multiplication operator
@@ -273,14 +205,6 @@ Double_t TVector3::Angle(const TVector3 & q) const
       if(arg < -1.0) arg = -1.0;
       return TMath::ACos(arg);
    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return the magnitude (rho in spherical coordinate system).
-
-Double_t TVector3::Mag() const
-{
-   return TMath::Sqrt(Mag2());
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
 * move important functions (constructors,destructors,accessors) to header
   to avoid overhead in creating and accessing these small objects
 * optimize access to TLorentzVector by avoiding a double switch statement
   (switch on direction in TLorentzVector followed by same switch in TVector3)
