### PR TITLE
Remove superfluous IO instrumentation for many classes

### DIFF
--- a/graf2d/postscript/inc/TPDF.h
+++ b/graf2d/postscript/inc/TPDF.h
@@ -110,7 +110,7 @@ public:
    Double_t XtoPDF(Double_t x);
    Double_t YtoPDF(Double_t y);
 
-   ClassDef(TPDF,1)  //PDF driver
+   ClassDef(TPDF, 0);  //PDF driver
 };
 
 #endif

--- a/graf2d/postscript/inc/TSVG.h
+++ b/graf2d/postscript/inc/TSVG.h
@@ -73,7 +73,7 @@ public:
    Double_t XtoSVG(Double_t x);
    Double_t YtoSVG(Double_t y);
 
-   ClassDef(TSVG,1)  //SVG driver
+   ClassDef(TSVG, 0);  //SVG driver
 };
 
 #endif

--- a/graf2d/postscript/inc/TTeXDump.h
+++ b/graf2d/postscript/inc/TTeXDump.h
@@ -78,7 +78,7 @@ public:
    Float_t XtoTeX(Double_t x);
    Float_t YtoTeX(Double_t y);
 
-   ClassDef(TTeXDump,2)  //Tex driver
+   ClassDef(TTeXDump, 0);  //Tex driver
 };
 
 #endif

--- a/graf3d/eve/inc/TEveElementEditor.h
+++ b/graf3d/eve/inc/TEveElementEditor.h
@@ -52,7 +52,7 @@ public:
    void DoMainColor(Pixel_t color);
    void DoTransparency();
 
-   ClassDef(TEveElementEditor, 1); // Editor for TEveElement class.
+   ClassDef(TEveElementEditor, 0); // Editor for TEveElement class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveEventManager.h
+++ b/graf3d/eve/inc/TEveEventManager.h
@@ -39,7 +39,7 @@ public:
    virtual void RemoveNewEventCommand(const TString& cmd);
    virtual void ClearNewEventCommands();
 
-   ClassDef(TEveEventManager, 1); // Base class for event management and navigation.
+   ClassDef(TEveEventManager, 0); // Base class for event management and navigation.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveFrameBox.h
+++ b/graf3d/eve/inc/TEveFrameBox.h
@@ -85,7 +85,7 @@ public:
    Bool_t GetDrawBack() const   { return fDrawBack; }
    void   SetDrawBack(Bool_t f) { fDrawBack = f;    }
 
-   ClassDef(TEveFrameBox, 1); // Description of a 2D or 3D frame that can be used to visually group a set of objects.
+   ClassDef(TEveFrameBox, 0); // Description of a 2D or 3D frame that can be used to visually group a set of objects.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGeoNode.h
+++ b/graf3d/eve/inc/TEveGeoNode.h
@@ -84,7 +84,7 @@ public:
    static Int_t GetCSGExportNSeg();
    static void  SetCSGExportNSeg(Int_t nseg);
 
-   ClassDef(TEveGeoNode, 1); // Wrapper for TGeoNode that allows it to be shown in GUI and controlled as a TEveElement.
+   ClassDef(TEveGeoNode, 0); // Wrapper for TGeoNode that allows it to be shown in GUI and controlled as a TEveElement.
 };
 
 //----------------------------------------------------------------
@@ -131,7 +131,7 @@ public:
    void VolumeColChanged(TGeoVolume* volume);
    void NodeVisChanged(TGeoNode* node);
 
-   ClassDef(TEveGeoTopNode, 1); // Top-level TEveGeoNode with a pointer to TGeoManager and controls for steering of TGeoPainter.
+   ClassDef(TEveGeoTopNode, 0); // Top-level TEveGeoNode with a pointer to TGeoManager and controls for steering of TGeoPainter.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGeoShape.h
+++ b/graf3d/eve/inc/TEveGeoShape.h
@@ -66,7 +66,7 @@ public:
    static TGeoManager*  GetGeoMangeur();
    static TGeoHMatrix*  GetGeoHMatrixIdentity();
 
-   ClassDef(TEveGeoShape, 2); // Wrapper for TGeoShape with absolute positioning and color attributes allowing display of extracted TGeoShape's (without an active TGeoManager) and simplified geometries (needed for NLT projections).
+   ClassDef(TEveGeoShape, 0); // Wrapper for TGeoShape with absolute positioning and color attributes allowing display of extracted TGeoShape's (without an active TGeoManager) and simplified geometries (needed for NLT projections).
 };
 
 //------------------------------------------------------------------------------

--- a/graf3d/eve/inc/TEvePointSet.h
+++ b/graf3d/eve/inc/TEvePointSet.h
@@ -96,7 +96,7 @@ public:
 
    virtual TClass* ProjectedClass(const TEveProjection* p) const;
 
-   ClassDef(TEvePointSet, 1); // Set of 3D points with same marker attributes; optionally each point can be assigned an external TRef or a number of integer indices.
+   ClassDef(TEvePointSet, 0); // Set of 3D points with same marker attributes; optionally each point can be assigned an external TRef or a number of integer indices.
 };
 
 
@@ -159,7 +159,7 @@ public:
 
    void SetRange(Double_t min, Double_t max);
 
-   ClassDef(TEvePointSetArray, 1); // Array of TEvePointSet's filled via a common point-source; range of displayed TEvePointSet's can be controlled, based on a separating quantity provided on fill-time by a user.
+   ClassDef(TEvePointSetArray, 0); // Array of TEvePointSet's filled via a common point-source; range of displayed TEvePointSet's can be controlled, based on a separating quantity provided on fill-time by a user.
 };
 
 
@@ -188,7 +188,7 @@ public:
    virtual void PointSelected(Int_t id);
 
 
-   ClassDef(TEvePointSetProjected, 1); // Projected copy of a TEvePointSet.
+   ClassDef(TEvePointSetProjected, 0); // Projected copy of a TEvePointSet.
 };
 
 #endif

--- a/graf3d/eve/inc/TEvePointSetArrayEditor.h
+++ b/graf3d/eve/inc/TEvePointSetArrayEditor.h
@@ -42,7 +42,7 @@ public:
 
    void DoRange();
 
-   ClassDef(TEvePointSetArrayEditor, 1); // Editor for TEvePointSetArray class.
+   ClassDef(TEvePointSetArrayEditor, 0); // Editor for TEvePointSetArray class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveProjectionAxes.h
+++ b/graf3d/eve/inc/TEveProjectionAxes.h
@@ -70,7 +70,7 @@ public:
 
    virtual const   TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
 
-   ClassDef(TEveProjectionAxes, 1); // Class to draw scales in non-linear projections.
+   ClassDef(TEveProjectionAxes, 0); // Class to draw scales in non-linear projections.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveRGBAPalette.h
+++ b/graf3d/eve/inc/TEveRGBAPalette.h
@@ -155,7 +155,7 @@ public:
 
    void MinMaxValChanged(); // *SIGNAL*
 
-   ClassDef(TEveRGBAPalette, 1); // A generic, speed-optimised mapping from value to RGBA color supporting different wrapping and range truncation modes.
+   ClassDef(TEveRGBAPalette, 0); // A generic, speed-optimised mapping from value to RGBA color supporting different wrapping and range truncation modes.
 };
 
 

--- a/graf3d/eve/inc/TEveRGBAPaletteEditor.h
+++ b/graf3d/eve/inc/TEveRGBAPaletteEditor.h
@@ -64,7 +64,7 @@ public:
    void DoUnderflowAction(Int_t mode);
    void DoOverflowAction(Int_t mode);
 
-   ClassDef(TEveRGBAPaletteSubEditor, 1); // Sub-editor for TEveRGBAPalette class.
+   ClassDef(TEveRGBAPaletteSubEditor, 0); // Sub-editor for TEveRGBAPalette class.
 };
 
 
@@ -87,7 +87,7 @@ public:
 
    virtual void SetModel(TObject* obj);
 
-   ClassDef(TEveRGBAPaletteEditor, 1); // Editor for TEveRGBAPalette class.
+   ClassDef(TEveRGBAPaletteEditor, 0); // Editor for TEveRGBAPalette class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveScalableStraightLineSet.h
+++ b/graf3d/eve/inc/TEveScalableStraightLineSet.h
@@ -33,6 +33,6 @@ public:
 
    Double_t GetScale() const;
 
-   ClassDef(TEveScalableStraightLineSet, 1); // Straight-line-set with extra scaling.
+   ClassDef(TEveScalableStraightLineSet, 0); // Straight-line-set with extra scaling.
 };
 #endif

--- a/graf3d/eve/inc/TEveStraightLineSet.h
+++ b/graf3d/eve/inc/TEveStraightLineSet.h
@@ -119,7 +119,7 @@ public:
    virtual void ComputeBBox();
    virtual void Paint(Option_t* option="");
 
-   ClassDef(TEveStraightLineSet, 1); // Set of straight lines with optional markers along the lines.
+   ClassDef(TEveStraightLineSet, 0); // Set of straight lines with optional markers along the lines.
 };
 
 
@@ -143,7 +143,7 @@ public:
    virtual void UpdateProjection();
    virtual TEveElement* GetProjectedAsElement() { return this; }
 
-   ClassDef(TEveStraightLineSetProjected, 1); // Projected copy of a TEveStraightLineSet.
+   ClassDef(TEveStraightLineSetProjected, 0); // Projected copy of a TEveStraightLineSet.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveStraightLineSetEditor.h
+++ b/graf3d/eve/inc/TEveStraightLineSetEditor.h
@@ -43,7 +43,7 @@ public:
    void DoRnrMarkers();
    void DoRnrLines();
 
-   ClassDef(TEveStraightLineSetEditor, 1); // Editor for TEveStraightLineSet class.
+   ClassDef(TEveStraightLineSetEditor, 0); // Editor for TEveStraightLineSet class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrack.h
+++ b/graf3d/eve/inc/TEveTrack.h
@@ -224,7 +224,7 @@ public:
 
    virtual TClass* ProjectedClass(const TEveProjection* p) const;
 
-   ClassDef(TEveTrackList, 1); // A list of tracks supporting change of common attributes and selection based on track parameters.
+   ClassDef(TEveTrackList, 0); // A list of tracks supporting change of common attributes and selection based on track parameters.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrackProjected.h
+++ b/graf3d/eve/inc/TEveTrackProjected.h
@@ -49,7 +49,7 @@ public:
 
    virtual void SecSelected(TEveTrack*); // marked as signal in TEveTrack
 
-   ClassDef(TEveTrackProjected, 1); // Projected copy of a TEveTrack.
+   ClassDef(TEveTrackProjected, 0); // Projected copy of a TEveTrack.
 };
 
 
@@ -78,7 +78,7 @@ public:
    virtual void SetDepth(Float_t d);
    virtual void SetDepth(Float_t d, TEveElement* el);
 
-   ClassDef(TEveTrackListProjected, 1); // Specialization of TEveTrackList for holding TEveTrackProjected objects.
+   ClassDef(TEveTrackListProjected, 0); // Specialization of TEveTrackList for holding TEveTrackProjected objects.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrackPropagatorEditor.h
+++ b/graf3d/eve/inc/TEveTrackPropagatorEditor.h
@@ -118,7 +118,7 @@ public:
 
    virtual void SetModel(TObject* obj);
 
-   ClassDef(TEveTrackPropagatorEditor, 1); // Editor for TEveTrackPropagator class.
+   ClassDef(TEveTrackPropagatorEditor, 0); // Editor for TEveTrackPropagator class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTransEditor.h
+++ b/graf3d/eve/inc/TEveTransEditor.h
@@ -81,7 +81,7 @@ public:
 
    virtual void SetModel(TObject* obj);
 
-   ClassDef(TEveTransEditor, 1); // Editor for TEveTrans class.
+   ClassDef(TEveTransEditor, 0); // Editor for TEveTrans class.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLLightSetEditor.h
+++ b/graf3d/gl/inc/TGLLightSetEditor.h
@@ -67,7 +67,7 @@ public:
 
    virtual void SetModel(TObject* obj);
 
-   ClassDef(TGLLightSetEditor, 1) // Editor for TGLLightSet.
+   ClassDef(TGLLightSetEditor, 0); // Editor for TGLLightSet.
 }; // endclass TGLLightSetEditor
 
 #endif

--- a/graf3d/gviz3d/inc/TStructNodeEditor.h
+++ b/graf3d/gviz3d/inc/TStructNodeEditor.h
@@ -58,7 +58,7 @@ public:
    void  Update(Bool_t resetCamera);
    void  Update();
 
-   ClassDef(TStructNodeEditor,1) // GUI fo editing TStructNode
+   ClassDef(TStructNodeEditor, 0); // GUI fo editing TStructNode
 };
 #endif // ROOT_TStructNodeEditor
 

--- a/graf3d/gviz3d/inc/TStructViewerGUI.h
+++ b/graf3d/gviz3d/inc/TStructViewerGUI.h
@@ -118,7 +118,7 @@ public:
    void           Update(Bool_t resetCamera = false);
    void           UpdateButtonSlot();
 
-   ClassDef(TStructViewerGUI, 1); // A GUI fo 3D struct viewer
+   ClassDef(TStructViewerGUI, 0); // A GUI fo 3D struct viewer
 };
 
 #endif

--- a/gui/gui/inc/TGWindow.h
+++ b/gui/gui/inc/TGWindow.h
@@ -131,7 +131,7 @@ public:
 
    static Int_t        GetCounter();
 
-   ClassDef(TGWindow,1)  // GUI Window base class
+   ClassDef(TGWindow, 0);  // GUI Window base class
 };
 
 

--- a/hist/hist/inc/TBackCompFitter.h
+++ b/hist/hist/inc/TBackCompFitter.h
@@ -157,7 +157,7 @@ private:
 
 
 
-   ClassDef(TBackCompFitter,1)  // Class providing backward compatibility for fitting by implementing the TVirtualFitter interface
+   ClassDef(TBackCompFitter, 0);  // Class providing backward compatibility for fitting by implementing the TVirtualFitter interface
 
 };
 

--- a/hist/hist/inc/TFitResult.h
+++ b/hist/hist/inc/TFitResult.h
@@ -70,7 +70,7 @@ public:
    }
 
 private:
-   ClassDef(TFitResult,1)  // Class holding the result of the fit
+   ClassDef(TFitResult, 0);  // Class holding the result of the fit
 };
 
 #endif

--- a/io/sql/inc/TBufferSQL2.h
+++ b/io/sql/inc/TBufferSQL2.h
@@ -306,7 +306,7 @@ public:
 
    // end of redefined virtual functions
 
-ClassDef(TBufferSQL2,1);    //a specialized TBuffer to convert data to SQL statements or read data from SQL tables
+   ClassDef(TBufferSQL2, 0);    //a specialized TBuffer to convert data to SQL statements or read data from SQL tables
 };
 
 #endif

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -345,7 +345,7 @@ protected:
 
    static std::string fgFloatFmt;          ///<!   Printf argument for floats and doubles, either "%f" or "%e" or "%10f" and so on
 
-ClassDef(TBufferXML,2) //a specialized TBuffer to read/write to XML files
+   ClassDef(TBufferXML, 0); //a specialized TBuffer to read/write to XML files
 };
 
 //______________________________________________________________________________

--- a/math/minuit/inc/TLinearFitter.h
+++ b/math/minuit/inc/TLinearFitter.h
@@ -280,7 +280,7 @@ public:
    virtual void      SetFitMethod(const char * /*name*/) {;}
    virtual Int_t     SetParameter(Int_t /*ipar*/,const char * /*parname*/,Double_t /*value*/,Double_t /*verr*/,Double_t /*vlow*/, Double_t /*vhigh*/) {return 0;}
 
-   ClassDef(TLinearFitter, 2) //fit a set of data points with a linear combination of functions
+   ClassDef(TLinearFitter, 0); //fit a set of data points with a linear combination of functions
 };
 
 #endif

--- a/net/net/inc/TParallelMergingFile.h
+++ b/net/net/inc/TParallelMergingFile.h
@@ -61,7 +61,7 @@ public:
    virtual Int_t  Write(const char *name=0, Int_t opt=0, Int_t bufsiz=0) const;
    virtual void   WriteStreamerInfo();
 
-   ClassDef(TParallelMergingFile,2);  // TFile specialization that will semi-automatically upload its content to a merging server.
+   ClassDef(TParallelMergingFile, 0);  // TFile specialization that will semi-automatically upload its content to a merging server.
 };
 
 #endif // ROOT_TParallelMergingFile

--- a/net/net/inc/TServerSocket.h
+++ b/net/net/inc/TServerSocket.h
@@ -94,7 +94,7 @@ public:
    static void        SetAcceptOptions(UChar_t Opt);
    static void        ShowAcceptOptions();
 
-   ClassDef(TServerSocket,1)  //This class implements server sockets
+   ClassDef(TServerSocket, 0);  //This class implements server sockets
 };
 
 #endif

--- a/tree/tree/inc/TBufferSQL.h
+++ b/tree/tree/inc/TBufferSQL.h
@@ -128,7 +128,7 @@ public:
    virtual   void     ReadFastArray(void  *, const TClass *, Int_t n=1, TMemberStreamer *s=0, const TClass *onFileClass=0);
    virtual   void     ReadFastArray(void **, const TClass *, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=0, const TClass *onFileClass=0);
 
-   ClassDef(TBufferSQL, 1); // Implementation of TBuffer to load and write to a SQL database
+   ClassDef(TBufferSQL, 0); // Implementation of TBuffer to load and write to a SQL database
 
 };
 


### PR DESCRIPTION
This somewhat huge commit mainly demotes many class-versions to 0. 

If wanted, I can for sure squash some things (right now, the commit messages contain the underlying reasoning). 

In ROOT, a lot of classes were equipped with class-versions > 0 even though they are not meant for IO / streaming. 
This produces unnecessary overhead (creation of Streamer() functions) and might be misleading for users (especially if they believe streaming of these classes would be ok and then lose parts of their data). That's even more helpful when testing framework's dataobject-code. 

These classes were identified by https://github.com/olifre/rootStaticAnalyzer (a new project still in early stages) and I have created this PR to fix almost all these issues. 

The last commit in the series also explicitly marks two members (of TSeqCollection and THashList) as transient, even though these classes are already class-version 0. This is purely to make it more explicit that these are not streamed - and allow for programmatic testing (since then the `kTransient` bit of the `TRealData` will be set correctly). 

Several issues alerted by `rootStaticAnalyzer` still remain which are probably real bugs in ROOT 6. 

Examples: 
```
TMVA/PDF.h:0: error: Data object class 'TMVA::PDF' will not stream the following indirect members: members 'fConfigName, fConfigDescription, fReferenceFile' from class 'TMVA::Configurable' (class-version 0)!
```
It seems like `TMVA::PDF` is meant for streaming, but inherits from a base which is not. 

Similar to that:
```
include/TTreeResult.h:0: error: Data object class 'TTreeResult' will not stream the following indirect members: members 'fRowCount' from class 'TSQLResult' (class-version 0)!
```