### PR TITLE
Fix bad streaming

### DIFF
--- a/core/base/inc/TColorGradient.h
+++ b/core/base/inc/TColorGradient.h
@@ -97,7 +97,7 @@ public:
 private:
    void RegisterColor(Color_t colorIndex);
 
-   ClassDef(TColorGradient, 1) //Gradient fill.
+   ClassDef(TColorGradient, 0); //Gradient fill.
 };
 
 class TLinearGradient : public TColorGradient {
@@ -118,7 +118,7 @@ private:
    Point fStart;
    Point fEnd;
 
-   ClassDef(TLinearGradient, 1)//Linear gradient fill.
+   ClassDef(TLinearGradient, 0); //Linear gradient fill.
 };
 
 //
@@ -170,7 +170,7 @@ private:
 
    EGradientType fType = kSimple;
 
-   ClassDef(TRadialGradient, 1)//Radial gradient fill.
+   ClassDef(TRadialGradient, 0); //Radial gradient fill.
 };
 
 

--- a/hist/hist/inc/TFractionFitter.h
+++ b/hist/hist/inc/TFractionFitter.h
@@ -109,7 +109,7 @@ protected:
 
    Int_t     fNpar;               // number of fit parameters
 
-   ClassDef(TFractionFitter, 1)   // Fits MC fractions to data histogram
+   ClassDef(TFractionFitter, 0);   // Fits MC fractions to data histogram
 };
 
 //

--- a/io/io/inc/TZIPFile.h
+++ b/io/io/inc/TZIPFile.h
@@ -189,7 +189,7 @@ public:
 
    void      Print(Option_t *option = "") const;
 
-   ClassDef(TZIPMember,2)  //A ZIP archive member file
+   ClassDef(TZIPMember, 0);  //A ZIP archive member file
 };
 
 #endif

--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -125,7 +125,7 @@ protected:
    TList                    *fDimensionSetup; //! list of dimension setups, for delayed creation of the dimension information.
    std::vector<std::string>  fAliasesUsed;    //! List of aliases used during the parsing of the expression.
 
-   LongDouble_t*        fConstLD;   // local version of fConsts able to store bigger numbers
+   LongDouble_t*        fConstLD;   //! local version of fConsts able to store bigger numbers
 
    TTreeFormula(const char *name, const char *formula, TTree *tree, const std::vector<std::string>& aliases);
    void Init(const char *name, const char *formula);
@@ -206,7 +206,7 @@ public:
    virtual TTree*      GetTree() const {return fTree;}
    virtual void        UpdateFormulaLeaves();
 
-   ClassDef(TTreeFormula,9)  //The Tree formula
+   ClassDef(TTreeFormula, 10);  //The Tree formula
 };
 
 #endif


### PR DESCRIPTION
This goes hand-in-hand with #169 . 
These were found in a different way, though: 
By creating them with their default constructor and trying to stream them to a memory buffer (the "StreamingTest" of https://github.com/olifre/rootStaticAnalyzer ). 

This PR demotes some class-versions for classes which break when streamed (and which are not supposed to be streamed) and makes one more member transient which should be transient (in TTreeFormula). 

There's one more remaining issue:
```
Error in <TStreamerInfo::Build>: TRandom1, discarding: const unsigned int* fTheSeeds, no [dimension]
```
I'm not sure what the "dimension" should be for this member - it's not so clear from the ranlux code to me. 

More issues are probably still there since rootStaticAnalyzer right now excludes some classes from testing completely if their construction / destruction using the default constructor fails. 