### PR TITLE
TProtoClass: Initialize also the fCheckSum member.

### DIFF
--- a/core/meta/inc/TProtoClass.h
+++ b/core/meta/inc/TProtoClass.h
@@ -94,7 +94,7 @@ private:
 
 public:
    TProtoClass():
-      fBase(0), fEnums(0), fSizeof(0), fCanSplit(0),
+      fBase(0), fEnums(0), fSizeof(0), fCheckSum(0), fCanSplit(0),
       fStreamerType(0), fProperty(0), fClassProperty(0),
       fOffsetStreamer(0) {
    }


### PR DESCRIPTION
This was missing in the default constructor. 

Found automatically by https://github.com/olifre/rootStaticAnalyzer : 
```
include/TProtoClass.h:78: error: Streamed member 'unsigned int fCheckSum' of dataobject 'TProtoClass' not initialized by constructor!
```
using the new test https://github.com/olifre/rootStaticAnalyzer/blob/master/src/tests/testStreamingUninitialized.cpp which identifies to-be-streamed members which are not initialized by the default constructors. 
There are likely more, but the other cases seem a bit more complex - I'm still working on improving the test. 