### PR TITLE
Fix errors with GCC 6.1.1 and Python 3.5

### DIFF
--- a/tmva/pymva/src/MethodPyAdaBoost.cxx
+++ b/tmva/pymva/src/MethodPyAdaBoost.cxx
@@ -24,6 +24,11 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#if PY_VERSION_HEX >= 0x03000000
+#define PyString_FromString PyBytes_FromString
+#define PyString_AsString PyBytes_AsString
+#endif
+
 #include "TMath.h"
 #include "Riostream.h"
 #include "TMatrix.h"

--- a/tmva/pymva/src/MethodPyGTB.cxx
+++ b/tmva/pymva/src/MethodPyGTB.cxx
@@ -25,6 +25,11 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#if PY_VERSION_HEX >= 0x03000000
+#define PyString_FromString PyBytes_FromString
+#define PyString_AsString PyBytes_AsString
+#endif
+
 #include "TMath.h"
 #include "Riostream.h"
 #include "TMatrix.h"

--- a/tmva/pymva/src/MethodPyRandomForest.cxx
+++ b/tmva/pymva/src/MethodPyRandomForest.cxx
@@ -24,6 +24,11 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#if PY_VERSION_HEX >= 0x03000000
+#define PyString_FromString PyBytes_FromString
+#define PyString_AsString PyBytes_AsString
+#endif
+
 #include "TMath.h"
 #include "Riostream.h"
 #include "TMatrix.h"

--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -20,6 +20,10 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#if PY_VERSION_HEX >= 0x03000000
+#define PyString_FromString PyBytes_FromString
+#endif
+
 
 using namespace TMVA;
 
@@ -133,7 +137,15 @@ void PyMethodBase::PyFinalize()
 }
 void PyMethodBase::PySetProgramName(TString name)
 {
+   #if PY_VERSION_HEX >= 0x03000000
+   const char* char_name = const_cast<char *>(name.Data());
+   const size_t size = strlen(char_name)+1;
+   wchar_t wchar_name[size];
+   mbstowcs(wchar_name, char_name, size);
+   Py_SetProgramName(wchar_name);
+   #else
    Py_SetProgramName(const_cast<char *>(name.Data()));
+   #endif
 }
 //_______________________________________________________________________
 TString PyMethodBase::Py_GetProgramName()


### PR DESCRIPTION
ROOT won't compile because of changes in the Python 3 API together with
GCC 6.1 release. The code changes fixes the issues on my machine running
Arch Linux (except for an error in Python 3.5 numpy/__multiarray_api.h)