### PR TITLE
Compression namespace

### DIFF
--- a/core/zip/inc/Compression.h
+++ b/core/zip/inc/Compression.h
@@ -12,7 +12,9 @@
 #ifndef ROOT_Compression
 #define ROOT_Compression
 
+#if defined(__cplusplus)
 namespace ROOT {
+#endif
 
    // The global settings depend on a global variable named
    // R__ZipMode which can be modified by a global function
@@ -39,8 +41,10 @@ namespace ROOT {
                                 kUndefinedCompressionAlgorithm
    };
 
+#if defined(__cplusplus)
    int CompressionSettings(ECompressionAlgorithm algorithm,
                            int compressionLevel);
 }
+#endif
 
 #endif

--- a/core/zip/src/Bits.h
+++ b/core/zip/src/Bits.h
@@ -13,6 +13,7 @@
  */
 
 #include "zlib.h"
+#include "Compression.h"
 #include "RConfigure.h"
 #include "ZipLZMA.h"
 
@@ -575,12 +576,12 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
     return;
   }
 
-  if (compressionAlgorithm == 0) {
+  if (compressionAlgorithm == ROOT::kUseGlobalSetting) {
     compressionAlgorithm = R__ZipMode;
   }
 
   // The LZMA compression algorithm from the XZ package
-  if (compressionAlgorithm == 2) {
+  if (compressionAlgorithm == ROOT::kLZMA) {
     R__zipLZMA(cxlevel, srcsize, src, tgtsize, tgt, irep);
     return;
   }
@@ -588,7 +589,7 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
   // The very old algorithm for backward compatibility
   // 0 for selecting with R__ZipMode in a backward compatible way
   // 3 for selecting in other cases
-  if (compressionAlgorithm == 3 || compressionAlgorithm == 0) {
+  if (compressionAlgorithm == ROOT::kOldCompressionAlgo || compressionAlgorithm == ROOT::kUseGlobalSetting) {
     bits_internal_state state;
     ush att      = (ush)UNKNOWN;
     ush flags    = 0;

--- a/core/zip/src/Bits.h
+++ b/core/zip/src/Bits.h
@@ -294,7 +294,7 @@ struct bits_internal_state {
    is done. LZMA typically has significantly higher compression factors, but takes
    more CPU time and memory resources while compressing.
 */
-int R__ZipMode = 1;
+enum ECompressionAlgorithm R__ZipMode = 1;
 
 /* ===========================================================================
  *  Prototypes for local functions
@@ -305,7 +305,7 @@ local void R__flush_outbuf OF((bits_internal_state *state, unsigned w, unsigned 
 /* ===========================================================================
    Function to set the ZipMode
  */
-void R__SetZipMode(int mode)
+void R__SetZipMode(enum ECompressionAlgorithm mode)
 {
    R__ZipMode = mode;
 }
@@ -576,12 +576,12 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
     return;
   }
 
-  if (compressionAlgorithm == ROOT::kUseGlobalSetting) {
+  if (compressionAlgorithm == kUseGlobalSetting) {
     compressionAlgorithm = R__ZipMode;
   }
 
   // The LZMA compression algorithm from the XZ package
-  if (compressionAlgorithm == ROOT::kLZMA) {
+  if (compressionAlgorithm == kLZMA) {
     R__zipLZMA(cxlevel, srcsize, src, tgtsize, tgt, irep);
     return;
   }
@@ -589,7 +589,7 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, char *src, int *tgtsize,
   // The very old algorithm for backward compatibility
   // 0 for selecting with R__ZipMode in a backward compatible way
   // 3 for selecting in other cases
-  if (compressionAlgorithm == ROOT::kOldCompressionAlgo || compressionAlgorithm == ROOT::kUseGlobalSetting) {
+  if (compressionAlgorithm == kOldCompressionAlgo || compressionAlgorithm == kUseGlobalSetting) {
     bits_internal_state state;
     ush att      = (ush)UNKNOWN;
     ush flags    = 0;


### PR DESCRIPTION
* exclude ECompressionAlgorithm from namespace ROOT in C (namespaces are a C++ thing)
* that enables using Compression.h in C
* Bits.h can then use ECompressionAlgorithm instead of hard coded numbers