### PR TITLE
Master tmva gsoc2016

### DIFF
--- a/tmva/tmva/inc/TMVA/Configurable.h
+++ b/tmva/tmva/inc/TMVA/Configurable.h
@@ -124,12 +124,10 @@ namespace TMVA {
       TString     fConfigDescription;   // description of this configurable
       TString     fReferenceFile;       // reference file for options writing
 
-   protected:
-
-      // the mutable declaration is needed to use the logger in const methods
-      MsgLogger& Log() const { return *fLogger; }                       
-
    public:
+     
+      // the mutable declaration is needed to use the logger in const methods
+      MsgLogger& Log() const { return *fLogger; }  
 
       // set message type
       void SetMsgType( EMsgType t ) { fLogger->SetMinType(t); }

--- a/tmva/tmva/inc/TMVA/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DataLoader.h
@@ -169,7 +169,7 @@ namespace TMVA {
       void ValidationKFoldSet();
       std::vector<TTree*> SplitSets(TTree * oldTree, int seedNum, int numFolds);
 
- 
+      const DataSetInfo& GetDefaultDataSetInfo(){ return DefaultDataSetInfo(); }
  
    private:
 

--- a/tmva/tmva/inc/TMVA/MethodBase.h
+++ b/tmva/tmva/inc/TMVA/MethodBase.h
@@ -499,6 +499,8 @@ namespace TMVA {
       void             AddInfoItem( void* gi, const TString& name,
                                     const TString& value) const;
 
+   public:
+     
       static void      CreateVariableTransforms(const TString& trafoDefinition,
                                                 TMVA::DataSetInfo& dataInfo,
                                                 TMVA::TransformationHandler& transformationHandler,


### PR DESCRIPTION
Hi Enric,

The next 3 items was applied.

- DefaultDataSetInfo: Omar will add a public method to DataLoader for getting a const reference to the DataSetInfo. This is needed by both Attila and Georgios.
- Configurable::Log: Omar will make it public. Attila needs this.
- MethodBase::CreateVariableTransforms: make it public. Attila needs this.

The last one is an static method in the class MethodBase, then may you can call it in python
from ROOT import TMVA
TMVA.MethodBase.CreateVariableTransforms

Best 
Omar.

