### PR TITLE
minimal check if branch name could cause problems

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -41,6 +41,7 @@
 #include "TVirtualPad.h"
 
 #include <atomic>
+#include <regex>
 #include <cstddef>
 #include <string.h>
 #include <stdio.h>
@@ -278,6 +279,13 @@ TBranch::TBranch(TBranch *parent, const char* name, void* address, const char* l
 void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
 {
    // Initialization routine called from the constructor.  This should NOT be made virtual.
+
+   if (!std::regex_match(name,std::regex("([a-zA-Z_][a-zA-Z0-9_]*)"))) {
+      Warning("TBranch","Branch name is not an allowed c++ variable name. This can lead to problems in MakeClass");
+   }
+   if (TString(name).BeginsWith("b_")) {
+      Warning("TBranch","Branch name begins with 'b_'. This may lead to confusion or problems in MakeClass");
+   }
 
    SetBit(TBranch::kDoNotUseBufferMap);
    if ((compress == -1) && fTree->GetDirectory()) {

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -39,9 +39,9 @@
 #include "TTreeCacheUnzip.h"
 #include "TVirtualMutex.h"
 #include "TVirtualPad.h"
+#include "TRegexp.h"
 
 #include <atomic>
-#include <regex>
 #include <cstddef>
 #include <string.h>
 #include <stdio.h>
@@ -280,7 +280,9 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
 {
    // Initialization routine called from the constructor.  This should NOT be made virtual.
 
-   if (!std::regex_match(name,std::regex("([a-zA-Z_][a-zA-Z0-9_]*)"))) {
+   Ssiz_t matchlength;
+   TRegexp reg("^[a-zA-Z_][a-zA-Z0-9_]*$");
+   if (0!=reg.Index(name,&matchlength)) {
       Warning("TBranch","Branch name is not an allowed c++ variable name. This can lead to problems in MakeClass");
    }
    if (TString(name).BeginsWith("b_")) {


### PR DESCRIPTION
The idea is to catch branch names, which will lead to problems when using the tree with `Draw` or `MakeClass`.
This can either be the member variables (branch names and `b_`branch names) which have to keep the generated code compilable (and ensure it does what it is expected to do). And the variable names should not lead to confusion with formula evaluation in Draw (e.g. branch names which are pure numbers).

The tests suggested here are:
 * test if branch name is a valid c++ variable name (w/o testing keywords).
 * test if branch name begins with "b_" (potential problem with MakeClass).

on top of that, I also have a [black list](https://github.com/pseyfert/tmva-branch-adder/blob/master/src/blacklist.cpp) of unfortunate branch names: methods of TTrees, which would clash in MakeClass, c++ keywords, variable types, and things TTree::Draw can parse (though I don't see how `TTree::Draw("cos(x)")` would clash with `TTree::Draw("cos")` if there is a variable named `cos`. Because the function `cos` wouldn't work without argument, and the variable `cos` wouldn't work with argument).

I only warn here and don't abort the branch initialisation, not to break third party code (variables with `.` are probably common [e.g. dynamically generated from float](http://lhcb-release-area.web.cern.ch/LHCb-release-area/DOC/davinci/latest_doxygen/d9/d80/_tuple_tool_cone_isolation_8cpp_source.html#l00204) )

Feedback request:
I'm unsure if putting the blacklist into TBranch.cxx is really the best solution to apply here.