### PR TITLE
Rewrite ROOT::Experimental::TDirectory[Entry].h, add cast to base class

### DIFF
--- a/core/base/v7/inc/ROOT/TDirectory.h
+++ b/core/base/v7/inc/ROOT/TDirectory.h
@@ -168,11 +168,13 @@ public:
   void Add(const std::string& name, const std::shared_ptr<T>& ptr) {
     Internal::TDirectoryEntry entry(ptr);
     // FIXME: CXX17: insert_or_assign
-    bool inserted = fContent.insert({name, entry}).second;
-    if (!inserted) {
+    auto idx = fContent.find(name);
+    if (idx != fContent.end()) {
       R__LOG_HERE(ELogLevel::kWarning, "CORE")
         << "Replacing object with name \"" << name << "\"" << std::endl;
-      fContent[name] = entry;
+      idx->second.swap(entry);
+    } else {
+      fContent[name].swap(entry);
     }
   }
 

--- a/core/base/v7/inc/ROOT/TDirectory.h
+++ b/core/base/v7/inc/ROOT/TDirectory.h
@@ -67,10 +67,8 @@ public:
 
 class TDirectory {
   /// The directory content is a hashed map of name =>
-  /// `Internal::TDirectoryEntryPtr`.
-  using ContentMap_t
-    = std::unordered_map<std::string,
-                         std::unique_ptr<Internal::TDirectoryEntryPtrBase>>;
+  /// `Internal::TDirectoryEntry`.
+  using ContentMap_t = std::unordered_map<std::string, Internal::TDirectoryEntry>;
 
   /// The `TDirectory`'s content.
   ContentMap_t fContent;
@@ -79,10 +77,8 @@ class TDirectory {
   struct ToContentType {
     using decaytype = typename std::decay<T>::type;
     using type = typename std::enable_if<
-      !std::is_function<decaytype>::value
-    && !std::is_pointer<decaytype>::value
-    && !std::is_member_object_pointer<decaytype>::value
-    && !std::is_member_function_pointer<decaytype>::value
+       !std::is_pointer<decaytype>::value
+    && !std::is_member_pointer<decaytype>::value
     && !std::is_void<decaytype>::value,
     decaytype>::type;
   };
@@ -96,47 +92,51 @@ public:
   /// \param name  - Key of the object.
   /// \param args  - arguments to be passed to the constructor of `T`
   template <class T, class... ARGS>
-  std::weak_ptr<T> Create(const std::string& name, ARGS... args) {
-    auto ptr = std::make_shared<ToContentType_t<T>>(std::forward<ARGS...>(args...));
+  decltype(auto) Create(const std::string& name, ARGS&&... args) {
+    auto ptr = std::make_shared<ToContentType_t<T>>(std::forward<ARGS>(args)...);
     Add(name, ptr);
     return ptr;
   }
 
-  /// Find the TDirectoryEntryPtrBase associated to the name. Returns nullptr if
+  /// Find the TDirectoryEntry associated to the name. Returns empty TDirectoryEntry if
   /// nothing is found.
-  const Internal::TDirectoryEntryPtrBase* Find(const std::string& name) const {
+  // FIXME: CXX17: return std::optional<TDirectoryEntry>
+  Internal::TDirectoryEntry Find(const std::string& name) const {
     auto idx = fContent.find(name);
     if (idx == fContent.end())
       return nullptr;
-    return idx->second.get();
+    return idx->second;
   }
 
   /**
   Status of the call to Find<T>(name).
   */
-  enum EFindStatus {
+  enum class EFindStatus {
     kValidValue,      ///< Value known for this key name and type
     kValidValueBase,  ///< Value known for this key name and base type
     kKeyNameNotFound, ///< No key is known for this name
     kTypeMismatch     ///< The provided type does not match the value's type.
   };
 
-  /// Find the TDirectoryEntryPtr<T> associated with the name.
-  /// \returns `nullptr` in `first` if nothing is found, or if the type does not
+  /// Find the TDirectoryEntry associated with the name.
+  /// \returns empty TDirectoryEntry in `first` if nothing is found, or if the type does not
   ///    match the expected type. `second` contains the reason.
-  /// \note returns `TDirectoryEntryPtrBase` instead of
-  ///    `TDirectoryEntryPtrBase<T>` to make this interface usable also passing
-  ///    a base. I.e. Find<Base>("name") can return TDirectoryEntryPtr<Derived>.
+  // FIXME: CXX17: return std::optional<TDirectoryEntry>
+  /// \note if `second` is kValidValue, then static_pointer_cast<`T`>(`first`.GetPointer())
+  ///    is shared_ptr<`T`> to initially stored object
+  /// \note if `second` is kValidValueBase, then `first`.CastPointer<`T`>()
+  ///    is a valid cast to base class `T` of the stored object
   template <class T>
-  std::pair<const Internal::TDirectoryEntryPtrBase*, EFindStatus>
+  std::pair<Internal::TDirectoryEntry, EFindStatus>
   Find(const std::string& name) const {
     auto idx = fContent.find(name);
     if (idx == fContent.end())
-      return std::make_pair(nullptr, kKeyNameNotFound);
-    // FIXME: implement upcast
-    if (idx->second->GetTypeInfo() == typeid(ToContentType_t<T>))
-      return std::make_pair(idx->second.get(), kValidValue);
-    return std::make_pair(nullptr, kTypeMismatch);
+      return {nullptr, EFindStatus::kKeyNameNotFound};
+    if (idx->second.GetTypeInfo() == typeid(ToContentType_t<T>))
+      return {idx->second, EFindStatus::kValidValue};
+    if (idx->second.CastPointer<ToContentType_t<T>>())
+      return {idx->second, EFindStatus::kValidValueBase};
+    return {nullptr, EFindStatus::kTypeMismatch};
   }
 
 
@@ -148,35 +148,31 @@ public:
   /// \throws TDirectoryTypeMismatch if the object stored under this name is of
   ///   a type that is not a derived type of `T`.
   template <class T>
-  std::shared_ptr<T> Get(const std::string& name) {
-    ContentMap_t::iterator idx = fContent.find(name);
+  decltype(auto) Get(const std::string& name) {
+    auto idx = fContent.find(name);
     if (idx != fContent.end()) {
-      // FIXME: implement upcast!
-      if (auto dep
-        = dynamic_cast<Internal::TDirectoryEntryPtr<T>*>(idx->second.get())) {
-        return dep->GetPointer();
-      }
+      if (idx->second.GetTypeInfo() == typeid(ToContentType_t<T>))
+        return std::static_pointer_cast<ToContentType_t<T>>(idx->second.GetPointer());
+      if (auto ptr = idx->second.CastPointer<ToContentType_t<T>>())
+        return ptr;
       // FIXME: add expected versus actual type name as c'tor args
       throw TDirectoryTypeMismatch(name);
     }
     throw TDirectoryUnknownKey(name);
-    return std::shared_ptr<T>(); // never happens
+    return std::shared_ptr<ToContentType_t<T>>(); // never happens
   }
 
   /// Add an existing object (rather a `shared_ptr` to it) to the TDirectory.
   /// The TDirectory will have shared ownership.
   template <class T>
   void Add(const std::string& name, const std::shared_ptr<T>& ptr) {
-    auto uptr = std::make_unique<Internal::TDirectoryEntryPtr<ToContentType_t<T>>>(ptr);
-    std::unique_ptr<Internal::TDirectoryEntryPtrBase> baseUPtr{std::move(uptr)};
-
-    ContentMap_t::iterator idx = fContent.find(name);
-    if (idx != fContent.end()) {
+    Internal::TDirectoryEntry entry(ptr);
+    // FIXME: CXX17: insert_or_assign
+    bool inserted = fContent.insert({name, entry}).second;
+    if (!inserted) {
       R__LOG_HERE(ELogLevel::kWarning, "CORE")
-        << "Replacing object with name " << name;
-      idx->second.swap(baseUPtr);
-    } else {
-      fContent[name].swap(baseUPtr);
+        << "Replacing object with name \"" << name << "\"" << std::endl;
+      fContent[name] = entry;
     }
   }
 

--- a/core/base/v7/inc/ROOT/TDirectory.h
+++ b/core/base/v7/inc/ROOT/TDirectory.h
@@ -92,7 +92,7 @@ public:
   /// \param name  - Key of the object.
   /// \param args  - arguments to be passed to the constructor of `T`
   template <class T, class... ARGS>
-  decltype(auto) Create(const std::string& name, ARGS&&... args) {
+  std::shared_ptr<ToContentType_t<T>> Create(const std::string& name, ARGS&&... args) {
     auto ptr = std::make_shared<ToContentType_t<T>>(std::forward<ARGS>(args)...);
     Add(name, ptr);
     return ptr;
@@ -148,7 +148,7 @@ public:
   /// \throws TDirectoryTypeMismatch if the object stored under this name is of
   ///   a type that is not a derived type of `T`.
   template <class T>
-  decltype(auto) Get(const std::string& name) {
+  std::shared_ptr<ToContentType_t<T>> Get(const std::string& name) {
     auto idx = fContent.find(name);
     if (idx != fContent.end()) {
       if (idx->second.GetTypeInfo() == typeid(ToContentType_t<T>))
@@ -159,7 +159,7 @@ public:
       throw TDirectoryTypeMismatch(name);
     }
     throw TDirectoryUnknownKey(name);
-    return std::shared_ptr<ToContentType_t<T>>(); // never happens
+    return nullptr; // never happens
   }
 
   /// Add an existing object (rather a `shared_ptr` to it) to the TDirectory.

--- a/core/base/v7/inc/ROOT/TDirectory.h
+++ b/core/base/v7/inc/ROOT/TDirectory.h
@@ -100,7 +100,6 @@ public:
 
   /// Find the TDirectoryEntry associated to the name. Returns empty TDirectoryEntry if
   /// nothing is found.
-  // FIXME: CXX17: return std::optional<TDirectoryEntry>
   Internal::TDirectoryEntry Find(const std::string& name) const {
     auto idx = fContent.find(name);
     if (idx == fContent.end())
@@ -121,7 +120,6 @@ public:
   /// Find the TDirectoryEntry associated with the name.
   /// \returns empty TDirectoryEntry in `first` if nothing is found, or if the type does not
   ///    match the expected type. `second` contains the reason.
-  // FIXME: CXX17: return std::optional<TDirectoryEntry>
   /// \note if `second` is kValidValue, then static_pointer_cast<`T`>(`first`.GetPointer())
   ///    is shared_ptr<`T`> to initially stored object
   /// \note if `second` is kValidValueBase, then `first`.CastPointer<`T`>()

--- a/core/base/v7/inc/ROOT/TDirectoryEntry.h
+++ b/core/base/v7/inc/ROOT/TDirectoryEntry.h
@@ -64,7 +64,7 @@ public:
   template<class U>
   std::shared_ptr<U> CastPointer() const;
 
-  explicit operator bool() const { return *fTypeInfo != typeid(std::nullptr_t); }
+  explicit operator bool() const { return !!fObj; }
 
 private:
   time_point_t fDate = clock_t::now(); ///< Time of last change

--- a/core/base/v7/inc/ROOT/TDirectoryEntry.h
+++ b/core/base/v7/inc/ROOT/TDirectoryEntry.h
@@ -95,15 +95,6 @@ inline void swap(TDirectoryEntry& e1, TDirectoryEntry& e2) noexcept
   e1.swap(e2);
 }
 
-inline bool operator==(const TDirectoryEntry& lhs, const TDirectoryEntry& rhs)
-{
-  return lhs.GetPointer() == rhs.GetPointer()
-    && lhs.GetTypeInfo() == rhs.GetTypeInfo();
-}
-
-inline bool operator!=(const TDirectoryEntry& lhs, const TDirectoryEntry& rhs)
-{ return !(lhs == rhs); }
-
 } // namespace Internal
 
 } // namespace Experimental

--- a/core/base/v7/inc/ROOT/TDirectoryEntry.h
+++ b/core/base/v7/inc/ROOT/TDirectoryEntry.h
@@ -65,6 +65,8 @@ public:
 
   explicit operator bool() const { return !!fObj; }
 
+  void swap(TDirectoryEntry& other) noexcept;
+
 private:
   time_point_t fDate = clock_t::now(); ///< Time of last change
   TClass* fType;
@@ -77,6 +79,20 @@ std::shared_ptr<U> TDirectoryEntry::CastPointer() const
   if (auto ptr = fType->DynamicCast(TClass::GetClass(typeid(U)), fObj.get()))
     return std::shared_ptr<U>(fObj, static_cast<U*>(ptr));
   return std::shared_ptr<U>();
+}
+
+inline void TDirectoryEntry::swap(TDirectoryEntry& other) noexcept
+{
+  using std::swap;
+
+  swap(fDate, other.fDate);
+  swap(fType, other.fType);
+  swap(fObj, other.fObj);
+}
+
+inline void swap(TDirectoryEntry& e1, TDirectoryEntry& e2) noexcept
+{
+  e1.swap(e2);
 }
 
 inline bool operator==(const TDirectoryEntry& lhs, const TDirectoryEntry& rhs)

--- a/core/base/v7/inc/ROOT/TDirectoryEntry.h
+++ b/core/base/v7/inc/ROOT/TDirectoryEntry.h
@@ -40,7 +40,6 @@ public:
     TDirectoryEntry(std::make_shared<T>(*ptr)) {}
   template<class T>
   explicit TDirectoryEntry(const std::shared_ptr<T>& ptr):
-    fTypeInfo(&typeid(T)),
     fType(TClass::GetClass(typeid(T))),
     fObj(ptr) {}
 
@@ -52,7 +51,7 @@ public:
   void SetChanged() { fDate = clock_t::now(); }
 
   /// Type of the object represented by this entry.
-  const std::type_info& GetTypeInfo() const { return *fTypeInfo; }
+  const std::type_info& GetTypeInfo() const { return *fType->GetTypeInfo(); }
 
   /// Get the object's type.
   TClass* GetType() const { return fType; }
@@ -68,7 +67,6 @@ public:
 
 private:
   time_point_t fDate = clock_t::now(); ///< Time of last change
-  const std::type_info* fTypeInfo;
   TClass* fType;
   std::shared_ptr<void> fObj;
 };

--- a/core/base/v7/inc/ROOT/TDirectoryEntry.h
+++ b/core/base/v7/inc/ROOT/TDirectoryEntry.h
@@ -26,76 +26,69 @@ namespace Experimental {
 
 namespace Internal {
 
-/**
-  Abstract base for a `TDirectory` element.
- */
-class TDirectoryEntryPtrBase {
+class TDirectoryEntry {
 public:
-  virtual ~TDirectoryEntryPtrBase() {}
   using clock_t = std::chrono::system_clock;
   using time_point_t = std::chrono::time_point<clock_t>;
 
-private:
-  time_point_t fDate = clock_t::now(); ///< Time of last change
-  TClass* fType = 0; ///< The type of the object
-
-protected:
-  TDirectoryEntryPtrBase() = default;
-
 public:
-  /// Constructor setting the type.
-  TDirectoryEntryPtrBase(TClass* cl): fType(cl) {}
+  TDirectoryEntry(): TDirectoryEntry(nullptr) {}
+  TDirectoryEntry(std::nullptr_t):
+    TDirectoryEntry(std::make_shared<std::nullptr_t>(nullptr)) {}
+  template<class T>
+  explicit TDirectoryEntry(T* ptr):
+    TDirectoryEntry(std::make_shared<T>(*ptr)) {}
+  template<class T>
+  explicit TDirectoryEntry(const std::shared_ptr<T>& ptr):
+    fTypeInfo(&typeid(T)),
+    fType(TClass::GetClass(typeid(T))),
+    fObj(ptr) {}
 
   /// Get the last change date of the entry.
   const time_point_t& GetDate() const { return fDate; }
-
-  /// Get the object's type.
-  TClass* GetType() const { return fType; }
 
   /// Inform the entry that it has been modified, and needs to update its
   /// last-changed time stamp.
   void SetChanged() { fDate = clock_t::now(); }
 
-  /// Abstract interface to retrieve the address of the object represented by
-  /// this entry, if any.
-  virtual void* GetObjectAddr() const = 0;
+  /// Type of the object represented by this entry.
+  const std::type_info& GetTypeInfo() const { return *fTypeInfo; }
 
-  /// Abstract interface to retrieve the type of the object represented by this
-  /// entry.
-  virtual const std::type_info& GetTypeInfo() const = 0;
-};
-
-
-/**
- Type-aware part of an entry in a TDirectory. It can manage the lifetime of an
- object, or only inform about last-change date and the type of an object.
- */
-
-template <class T>
-class TDirectoryEntryPtr: public TDirectoryEntryPtrBase {
-public:
-  /// Initialize a TDirectoryEntryPtr from an existing object ("write").
-  TDirectoryEntryPtr(T&& obj):
-    TDirectoryEntryPtrBase(TClass::GetClass(typeid(T))),  fObj(obj) {}
-
-  /// Initialize a TDirectoryEntryPtr from an existing object ("write").
-  TDirectoryEntryPtr(const std::shared_ptr<T>& ptr): fObj(ptr) {}
-
-  virtual ~TDirectoryEntryPtr() {}
+  /// Get the object's type.
+  TClass* GetType() const { return fType; }
 
   /// Retrieve the `shared_ptr` of the referenced object.
-  std::shared_ptr<T>& GetPointer() const { return fObj; }
+  std::shared_ptr<void>& GetPointer() { return fObj; }
+  const std::shared_ptr<void>& GetPointer() const { return fObj; }
 
-  /// Retrieve the address of the object managed by this entry.
-  /// Returns `nullptr` if no object is managed by this entry.
-  void* GetObjectAddr() const final { return fObj.get(); }
+  template<class U>
+  std::shared_ptr<U> CastPointer() const;
 
-  /// Type of the object represented by this entry.
-  const std::type_info& GetTypeInfo() const final { return typeid(T); }
+  explicit operator bool() const { return *fTypeInfo != typeid(std::nullptr_t); }
 
 private:
-  std::shared_ptr<T> fObj; ///< Object referenced by this entry, if any.
+  time_point_t fDate = clock_t::now(); ///< Time of last change
+  const std::type_info* fTypeInfo;
+  TClass* fType;
+  std::shared_ptr<void> fObj;
 };
+
+template<class U>
+std::shared_ptr<U> TDirectoryEntry::CastPointer() const
+{
+  if (auto ptr = fType->DynamicCast(TClass::GetClass(typeid(U)), fObj.get()))
+    return std::shared_ptr<U>(fObj, static_cast<U*>(ptr));
+  return std::shared_ptr<U>();
+}
+
+inline bool operator==(const TDirectoryEntry& lhs, const TDirectoryEntry& rhs)
+{
+  return lhs.GetPointer() == rhs.GetPointer()
+    && lhs.GetTypeInfo() == rhs.GetTypeInfo();
+}
+
+inline bool operator!=(const TDirectoryEntry& lhs, const TDirectoryEntry& rhs)
+{ return !(lhs == rhs); }
 
 } // namespace Internal
 

--- a/io/io/v7/inc/ROOT/TFile.h
+++ b/io/io/v7/inc/ROOT/TFile.h
@@ -137,21 +137,12 @@ public:
   /// \throws TDirectoryTypeMismatch if the object stored under this name is of
   ///   a type different from `T`.
   template<class T>
-  std::unique_ptr <T> Read(std::string_view name) {
+  std::unique_ptr<T> Read(std::string_view name) {
     // FIXME: need separate collections for a TDirectory's key/value and registered objects. Here, we want to emit a read and must look through the key/values without attaching an object to the TDirectory.
-    if (const Internal::TDirectoryEntryPtrBase *dep = Find(name.to_string())) {
-      // FIXME: implement upcast!
       // FIXME: do not register read object in TDirectory
       // FIXME: implement actual read
-      if (auto depT = dynamic_cast<const Internal::TDirectoryEntryPtr <T> *>(dep)) {
         //FIXME: for now, copy out of whatever the TDirectory manages.
-        return std::make_unique<T>(*depT->GetPointer());
-      }
-      // FIXME: add expected versus actual type name as c'tor args
-      throw TDirectoryTypeMismatch(name.to_string());
-    }
-    throw TDirectoryUnknownKey(name.to_string());
-    return std::unique_ptr<T>(); // never happens
+    return std::make_unique<T>(*Get<T>(name));
   }
 
 
@@ -169,8 +160,8 @@ public:
 
   /// Write an object that is already lifetime managed by this TFileImplBase.
   void Write(std::string_view name) {
-    const Internal::TDirectoryEntryPtrBase *dep = Find(name.to_string());
-    WriteMemoryWithType(name, dep->GetObjectAddr(), dep->GetType());
+    auto dep = Find(name.to_string());
+    WriteMemoryWithType(name, dep.GetPointer().get(), dep.GetType());
   }
 
   /// Hand over lifetime management of an object to this TFileImplBase, and


### PR DESCRIPTION
Based on `TClass::DynamicCast()`.
`root` script to check it working https://gist.github.com/BerserkerTroll/b94c2d3e3a5848be7c7dd53e323e1cdb

Besides different cast method, some bugs were fixed, so #200 was actually broken, despite it compiles (nobody has instantiated broken templates). Consider @a885623b7f04d193b299097b189bbb1fd45139e1 (exception-based cast, without bugs) if you want to get rid of `TClass` or apply this https://gist.github.com/BerserkerTroll/b6624c5f74b71293bc9c2059b4e5236a patch to this PR.