### PR TITLE
Fixed bug in filter, changed how tutorials access files

### DIFF
--- a/documentation/doxygen/converttonotebook.py
+++ b/documentation/doxygen/converttonotebook.py
@@ -417,7 +417,9 @@ def mainfunction(text):
     ## The two commands to create an html version of the notebook and a notebook with the output
     print time.time() - starttime
     #subprocess.call(["jupyter", "nbconvert","--ExecutePreprocessor.timeout=60", "--to=html", "--execute",  outdir+outname])
-    subprocess.call(["jupyter", "nbconvert","--ExecutePreprocessor.timeout=60",  "--to=notebook", "--execute",  outdir+outname])
+    r = subprocess.call(["jupyter", "nbconvert","--ExecutePreprocessor.timeout=90",  "--to=notebook", "--execute",  outdir+outname])
+    if r != 0:
+         sys.stderr.write( "ERROR: Nbconvert failed for notebook %s \n" % outname)
     if jsroot:
         subprocess.call(["jupyter", "trust",  outdir+outnameconverted])
     os.remove(outdir+outname)

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -303,7 +303,13 @@ void FilterTutorial()
       if (gLineString.find("\\notebook") != string::npos) {
          ExecuteCommand(StringFormat("python converttonotebook.py %s %s/notebooks/",
                                           gFileName.c_str(), gOutDir.c_str()));
+         ReplaceAll(gLineString, "\\notebook -js", StringFormat( "\\htmlonly <a href=\"http://nbviewer.jupyter.org/url/root.cern.ch/doc/master/notebooks/%s.nbconvert.ipynb\" target=\"_blank\"><img src= notebook.gif alt=\"View in nbviewer\" style=\"height:1em\" ></a> <a href=\"https://cern.ch/swanserver/cgi-bin/go?projurl=https://root.cern.ch/doc/master/notebooks/%s.nbconvert.ipynb\" target=\"_blank\"><img src=\"http://swanserver.web.cern.ch/swanserver/images/badge_swan_white_150.png\"  alt=\"Open in SWAN\" style=\"height:1em\" ></a> \\endhtmlonly", gMacroName.c_str() , gMacroName.c_str()) );         
+         
+         ReplaceAll(gLineString, "\\notebook -nodraw", StringFormat( "\\htmlonly <a href=\"http://nbviewer.jupyter.org/url/root.cern.ch/doc/master/notebooks/%s.nbconvert.ipynb\" target=\"_blank\"><img src= notebook.gif alt=\"View in nbviewer\" style=\"height:1em\" ></a> <a href=\"https://cern.ch/swanserver/cgi-bin/go?projurl=https://root.cern.ch/doc/master/notebooks/%s.nbconvert.ipynb\" target=\"_blank\"><img src=\"http://swanserver.web.cern.ch/swanserver/images/badge_swan_white_150.png\"  alt=\"Open in SWAN\" style=\"height:1em\" ></a> \\endhtmlonly", gMacroName.c_str() , gMacroName.c_str()) );
+         
          ReplaceAll(gLineString, "\\notebook", StringFormat( "\\htmlonly <a href=\"http://nbviewer.jupyter.org/url/root.cern.ch/doc/master/notebooks/%s.nbconvert.ipynb\" target=\"_blank\"><img src= notebook.gif alt=\"View in nbviewer\" style=\"height:1em\" ></a> <a href=\"https://cern.ch/swanserver/cgi-bin/go?projurl=https://root.cern.ch/doc/master/notebooks/%s.nbconvert.ipynb\" target=\"_blank\"><img src=\"http://swanserver.web.cern.ch/swanserver/images/badge_swan_white_150.png\"  alt=\"Open in SWAN\" style=\"height:1em\" ></a> \\endhtmlonly", gMacroName.c_str() , gMacroName.c_str()) );
+
+         
       }
       // \macro_output found
       if (gLineString.find("\\macro_output") != string::npos) {

--- a/tutorials/fit/TwoHistoFit2D.C
+++ b/tutorials/fit/TwoHistoFit2D.C
@@ -116,8 +116,8 @@ int TwoHistoFit2D(bool global = true) {
   func->SetParameters(iniParams);
 
   // fill Histos
-  int n1 = 1000000;
-  int n2 = 1000000;
+  int n1 = 50000;
+  int n2 = 50000;
   //  h1->FillRandom("func", n1);
   //h2->FillRandom("func",n2);
   FillHisto(h1,n1,iniParams);

--- a/tutorials/fit/fit1.C
+++ b/tutorials/fit/fit1.C
@@ -1,5 +1,6 @@
 /// \file
 /// \ingroup tutorial_fit
+/// \notebook
 /// Simple fitting example (1-d histogram with an interpreted function)
 ///
 /// \macro_image
@@ -34,9 +35,8 @@ void fit1() {
    // We connect the ROOT file generated in a previous tutorial
    // (see begin_html <a href="fillrandom.C.html">Filling histograms with random numbers from a function</a>) end_html
    //
-   TString dir = gSystem->UnixPathName(__FILE__);
-   dir.ReplaceAll("fit1.C","");
-   dir.ReplaceAll("/./","/");
+   TString dir = gROOT->GetTutorialsDir();
+   dir.Append("/fit/");
    TFile *file = TFile::Open("fillrandom.root");
    if (!file) {
       gROOT->ProcessLine(Form(".x %s../hist/fillrandom.C",dir.Data()));
@@ -77,7 +77,7 @@ void fit1() {
    // We now annotate the picture by creating a PaveText object
    // and displaying the list of commands in this macro
    //
-   TPaveText * fitlabel = new TPaveText(0.6,0.3,0.9,0.80,"NDC");
+   TPaveText * fitlabel = new TPaveText(0.6,0.4,0.9,0.75,"NDC");
    fitlabel->SetTextAlign(12);
    fitlabel->SetFillColor(42);
    fitlabel->ReadFile(Form("%sfit1_C.txt",dir.Data()));

--- a/tutorials/fit/fit2.C
+++ b/tutorials/fit/fit2.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_fit
-/// Fitting a 2-D histogram
 /// \notebook
+/// Fitting a 2-D histogram
 /// This tutorial illustrates :
 ///  - how to create a 2-d function
 ///  - fill a 2-d histogram randomly from this function

--- a/tutorials/fit/fitpanel_playback.C
+++ b/tutorials/fit/fitpanel_playback.C
@@ -1,6 +1,5 @@
 /// \file
 /// \ingroup tutorial_fit
-/// \notebook
 /// This file will test all the transient frames (aka Dialog windows)
 /// displayed in the fitpanel, as the rest of the functionality is
 /// tried automatically with the UnitTest.C unit.

--- a/tutorials/fit/fitslicesy.C
+++ b/tutorials/fit/fitslicesy.C
@@ -1,5 +1,6 @@
 /// \file
 /// \ingroup tutorial_fit
+/// \notebook
 /// Illustrates how to use the TH1::FitSlicesY function
 /// It uses the TH2F histogram generated in macro hsimple.C
 /// It invokes FitSlicesY and draw the fitted "mean" and "sigma"
@@ -22,8 +23,8 @@ void fitslicesy() {
    gStyle->SetTitleH(0.1);
 
 // Connect the input file and get the 2-d histogram in memory
-   TString dir = gSystem->UnixPathName(__FILE__);
-   dir.ReplaceAll("fitslicesy.C","../hsimple.C");
+   TString dir = gROOT.GetTutorialsDir()
+   dir.Append("/hsimple.C")
    dir.ReplaceAll("/./","/");
    if (!gInterpreter->IsLoaded(dir.Data())) gInterpreter->LoadMacro(dir.Data());
    TFile *hsimple = (TFile*)gROOT->ProcessLineFast("hsimple(1)");

--- a/tutorials/fit/myfit.C
+++ b/tutorials/fit/myfit.C
@@ -1,5 +1,6 @@
 /// \file
 /// \ingroup tutorial_fit
+/// \notebook
 /// Get in memory an histogram from a root file and fit a user defined function.
 /// Note that a user defined function must always be defined
 /// as in this example:
@@ -24,8 +25,8 @@ Double_t fitf(Double_t *x, Double_t *par)
 }
 void myfit()
 {
-   TString dir = gSystem->UnixPathName(__FILE__);
-   dir.ReplaceAll("myfit.C","../hsimple.C");
+   TString dir = gROOT.GetTutorialsDir()
+   dir.Append("/hsimple.C")
    dir.ReplaceAll("/./","/");
    if (!gInterpreter->IsLoaded(dir.Data())) gInterpreter->LoadMacro(dir.Data());
    TFile *hsimple = (TFile*)gROOT->ProcessLineFast("hsimple(1)");

--- a/tutorials/graphics/gtime.C
+++ b/tutorials/graphics/gtime.C
@@ -1,6 +1,5 @@
 /// \file
 /// \ingroup tutorial_graphics
-/// \notebook
 /// Example of a graph of data moving in time.
 /// Use the canvas "File/Quit" to exit from this example
 ///

--- a/tutorials/graphics/tmathtext.C
+++ b/tutorials/graphics/tmathtext.C
@@ -1,6 +1,5 @@
 /// \file
 /// \ingroup tutorial_graphics
-/// \notebook
 /// This macro draws various formula in a canvas.
 /// It also prints the canvas as a Postscript file using TMathText.
 ///


### PR DESCRIPTION
Filter doesn't display command line option `-js` and `-nodraw` in the description anymore. Tutorials now use `gROOT->GetTutorialsDir()` to access tutorial files. converttonotebooks now displays an error message that is picked up by jenkins when nbconvert fails.