### PR TITLE
Added TChain-like interface to THnBase histograms.

### DIFF
--- a/hist/hist/CMakeLists.txt
+++ b/hist/hist/CMakeLists.txt
@@ -11,6 +11,6 @@ endif()
 
 ROOT_GENERATE_DICTIONARY(G__${libname} *.h Math/*.h v5/*.h ${Hist_v7_dict_headers} MODULE ${libname} LINKDEF LinkDef.h OPTIONS "-writeEmptyRootPCM")
 
-ROOT_LINKER_LIBRARY(${libname} *.cxx ${root7src} G__${libname}.cxx DEPENDENCIES Matrix MathCore)
+ROOT_LINKER_LIBRARY(${libname} *.cxx ${root7src} G__${libname}.cxx DEPENDENCIES Matrix MathCore RIO)
 ROOT_INSTALL_HEADERS()
 

--- a/hist/hist/inc/LinkDef.h
+++ b/hist/hist/inc/LinkDef.h
@@ -117,6 +117,7 @@
 #pragma link C++ class TNDArrayRef<const UShort_t>+;
 */
 #pragma link C++ class THn+;
+#pragma link C++ class THnChain+;
 #pragma link C++ class THnT<Float_t>+;
 //#pragma link C++ class THnT<Float16_t>+;
 #pragma link C++ class THnT<Double_t>+;

--- a/hist/hist/inc/THnChain.h
+++ b/hist/hist/inc/THnChain.h
@@ -1,0 +1,116 @@
+// @(#)root/hist:$Id$
+// Author: Benjamin Bannier, August 2016
+
+/*************************************************************************
+ * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_THnChain
+#define ROOT_THnChain
+
+#include <TObject.h>
+
+#include <string>
+#include <vector>
+
+class TAxis;
+class TH1;
+class TH2;
+class TH3;
+class THnBase;
+
+/** \class THnChain
+A class to chain together multiple histograms.
+
+This class allows to chain together any `THnBase`-derived (`THn` or `THnSparse`)
+histograms from multiple files. Operations on the axes and projections are
+supported. The intent is to allow convenient merging merging of projections
+of high-dimensional histograms.
+
+\code{.cpp}
+// `file1.root` and `file2.root` contain a `THnSparse` named `hsparse`.
+THnChain hs("hsparse");
+hs.AddFile("file1.root");
+hs.AddFile("file2.root");
+
+// Project out axis 0, integrate over other axes.
+TH1* h0 = hs.Projection(0);
+
+// Project out axis 0, integrate over other axes in their active ranges.
+hs.GetAxis(1)->SetRangeUser(0, 0.1); // select a subrange
+TH1* h0 = hs.Projection(0);
+\endcode
+*/
+
+class THnChain : public TObject
+{
+ public:
+   /// Default constructor.
+   ///
+   /// \param name name of the histogram to work on
+   explicit THnChain(const char* name) : fName(name) {}
+
+   /// Add a new file to this chain.
+   ///
+   /// \param fileName path of the file to add
+   void AddFile(const char* fileName);
+
+   /// Get an axis from the histogram.
+   ///
+   /// \param i index of the axis to retrieve
+   ///
+   /// This function requires that a file containing the histogram was
+   /// already added with `AddFile`.
+   ///
+   /// Properties set on the axis returned by `GetAxis` are propagated to all
+   /// histograms in the chain, so it can e.g. be used to set ranges for
+   /// projections.
+   TAxis* GetAxis(Int_t i) const;
+
+   /// See `THnBase::Projection` for the intended behavior.
+   TH1* Projection(Int_t xDim, Option_t* option = "") const;
+
+   /// See `THnBase::Projection` for the intended behavior.
+   TH2* Projection(Int_t yDim, Int_t xDim, Option_t* option = "") const;
+
+   /// See `THnBase::Projection` for the intended behavior.
+   TH3* Projection(Int_t xDim, Int_t yDim, Int_t zDim, Option_t* option = "") const;
+
+   /// See `THnBase::Projection` for the intended behavior.
+   THnBase* ProjectionND(Int_t ndim, const Int_t* dim, Option_t* option = "") const;
+
+ private:
+   std::string fName; ///< name of the histogram
+
+   std::vector<std::string> fFiles; ///< a list of files to extract the histogram from
+   std::vector<TAxis*> fAxes;       ///< the list of histogram axes
+
+   /// Projects all histograms in the chain.
+   ///
+   /// See `THnBase::Projection` for parameters and their semantics.
+   TObject* ProjectionAny(Int_t ndim, const Int_t* dim, Option_t* option = "") const;
+
+   /// Retrieve a histogram from a file.
+   ///
+   /// \param fileName path of the file to read.
+   THnBase* ReadHistogram(const char* fileName) const;
+
+   /// Copy the properties of all axes to a histogram.
+   ///
+   /// \param hs histogram whose axes should be updated
+   void SetupAxes(THnBase& hs) const;
+
+   /// Ensure a histogram has axes similar to the ones we expect.
+   ///
+   /// \param h histogram to verify
+   /// \param axes expected set of axes
+   static bool CheckConsistency(const THnBase& h, const std::vector<TAxis*>& axes);
+
+   ClassDef(THnChain, 0);
+};
+
+#endif

--- a/hist/hist/src/THnChain.cxx
+++ b/hist/hist/src/THnChain.cxx
@@ -1,0 +1,221 @@
+// @(#)root/hist:$Id$
+// Author: Benjamin Bannier, August 2016
+
+/*************************************************************************
+ * Copyright (C) 1995-2016, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "THnChain.h"
+
+#include "TArray.h"
+#include "TAxis.h"
+#include "TDirectory.h"
+#include "TFile.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TH3.h"
+#include "THnBase.h"
+#include "TMath.h"
+#include "TMetaUtils.h"
+
+void THnChain::AddFile(const char* fileName)
+{
+   fFiles.emplace_back(fileName);
+
+   // Initialize axes from first seen instance.
+   if (fAxes.empty()) {
+      THnBase* hs = ReadHistogram(fileName);
+
+      if (hs) {
+         const Int_t naxes = hs->GetNdimensions();
+         for (Int_t i = 0; i < naxes; ++i) {
+            fAxes.push_back(hs->GetAxis(i));
+         }
+      } else {
+          Warning("AddFile",
+                  "Could not find histogram %s in file %s",
+                  fName.c_str(),
+                  fileName);
+      }
+   }
+}
+
+TAxis* THnChain::GetAxis(Int_t i) const
+{
+   if (i < 0 || i >= static_cast<Int_t>(fAxes.size())) {
+      return nullptr;
+   }
+
+   return fAxes[i];
+}
+
+TObject* THnChain::ProjectionAny(Int_t ndim, const Int_t* dim, Option_t* option) const
+{
+   if (ndim <= 0) {
+      return nullptr;
+   }
+
+   TObject* h_merged = nullptr;
+   for (const auto& file : fFiles) {
+      THnBase* hs = ReadHistogram(file.c_str());
+
+      if (!hs) {
+         Warning("ProjectionAny",
+                 "Could not find histogram %s in file %s",
+                 fName.c_str(),
+                 file.c_str());
+
+         continue;
+      }
+
+      if (!CheckConsistency(*hs, fAxes)) {
+         Warning("ProjectionAny",
+                 "Histogram %s from file %s is inconsistent with the histogram from file %s",
+                 fName.c_str(),
+                 file.c_str(),
+                 fFiles[0].c_str());
+
+         continue;
+      }
+
+      SetupAxes(*hs);
+
+      // Perform projection.
+      TObject* h = nullptr;
+
+      if (ndim == 1) {
+         h = hs->Projection(dim[0], option);
+      } else if (ndim == 2) {
+         h = hs->Projection(dim[0], dim[1], option);
+      } else if (ndim == 3) {
+         h = hs->Projection(dim[0], dim[1], dim[2], option);
+      } else {
+         h = hs->ProjectionND(ndim, dim, option);
+      }
+
+      delete hs;
+
+      // Add this histogram.
+      if (h_merged) {
+         if (ndim < 3) {
+            static_cast<TH1*>(h_merged)->Add(static_cast<TH1*>(h));
+         } else {
+            static_cast<THnBase*>(h_merged)->Add(static_cast<THnBase*>(h));
+         }
+
+         delete h;
+      } else {
+         h_merged = h;
+      }
+   }
+
+   return h_merged;
+}
+
+THnBase* THnChain::ReadHistogram(const char* fileName) const
+{
+   TDirectory::TContext ctxt(gDirectory);
+
+   TFile* f = TFile::Open(fileName);
+
+   if (!f) {
+      return nullptr;
+   }
+
+   THnBase* hs = nullptr;
+   f->GetObject(fName.c_str(), hs);
+   delete f;
+
+   return hs;
+}
+
+void THnChain::SetupAxes(THnBase& hs) const
+{
+   const Int_t naxes = fAxes.size();
+   for (Int_t i = 0; i < naxes; ++i) {
+      const TAxis* ax_ref = fAxes[i];
+      TAxis* ax = hs.GetAxis(i);
+      ax_ref->Copy(*ax);
+   }
+}
+
+bool THnChain::CheckConsistency(const THnBase& h, const std::vector<TAxis*>& axes)
+{
+   // We would prefer to directly use `TH1::CheckEqualAxes` here;
+   // however it is protected so we inherit the parts we care about.
+   // FIXME(bbannier): It appears that functionality like `TH1::CheckEqualAxes` could
+   // just as well live in `TAxis` so that anyone using axes could make use of it.
+   const Int_t naxes = h.GetNdimensions();
+   const Int_t naxes2 = axes.size();
+
+   if (naxes != naxes2) {
+      return false;
+   }
+
+   for (Int_t i = 0; i < naxes; ++i) {
+      const TAxis* ax1 = h.GetAxis(i);
+      const TAxis* ax2 = axes[i];
+
+      if (ax1->GetNbins() != ax2->GetNbins()) {
+         return false;
+      }
+
+      // Copied from `TH1::CheckAxisLimits.`
+      if (!TMath::AreEqualRel(ax1->GetXmin(), ax2->GetXmin(), 1.E-12) ||
+          !TMath::AreEqualRel(ax1->GetXmax(), ax2->GetXmax(), 1.E-12)) {
+         return false;
+      }
+
+      // Copied from `TH1::CheckBinLimits`.
+      const TArrayD* h1Array = ax1->GetXbins();
+      const TArrayD* h2Array = ax2->GetXbins();
+      Int_t fN = h1Array->fN;
+      if (fN != 0) {
+         if (h2Array->fN != fN) {
+            return false;
+         } else {
+            for (int ibin = 0; ibin < fN; ++ibin) {
+               if (!TMath::AreEqualRel(h1Array->GetAt(ibin), h2Array->GetAt(ibin), 1E-10)) {
+                  return false;
+               }
+            }
+         }
+      }
+
+      // We ignore checking for equal bin labels here. A check
+      // for that is implemented in `TH1::CheckBinLabels`.
+   }
+
+   return true;
+}
+
+TH1* THnChain::Projection(Int_t xDim, Option_t* option) const
+{
+   // Forwards to `THnBase::Projection()`.
+   Int_t dim[1] = {xDim};
+   return static_cast<TH1*>(ProjectionAny(1, dim, option));
+}
+
+TH2* THnChain::Projection(Int_t yDim, Int_t xDim, Option_t* option) const
+{
+   // Forwards to `THnBase::Projection()`.
+   Int_t dim[2] = {xDim, yDim};
+   return static_cast<TH2*>(ProjectionAny(2, dim, option));
+}
+
+TH3* THnChain::Projection(Int_t xDim, Int_t yDim, Int_t zDim, Option_t* option) const
+{
+   // Forwards to `THnBase::Projection()`.
+   Int_t dim[3] = {xDim, yDim, zDim};
+   return static_cast<TH3*>(ProjectionAny(3, dim, option));
+}
+
+THnBase* THnChain::ProjectionND(Int_t ndim, const Int_t* dim, Option_t* option) const
+{
+   // Forwards to `THnBase::ProjectionND()`.
+   return static_cast<THnBase*>(ProjectionAny(ndim, dim, option));
+}


### PR DESCRIPTION
This allows to interactively adjust histogram parameters before
performing a projection to a lower dimensional representation.

This patch implements ROOT-4515.

A unit test is being added in root-mirror/roottest/pull/6.
