### PR TITLE
Fix leading whitespace CMake error.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -92,7 +92,7 @@ elseif(cocoa)
 endif()
 
 if(APPLE)
-  set(corelinklibs "${corelinklibs} -F /System/Library/PrivateFrameworks -framework CoreSymbolication")
+  set(corelinklibs "${corelinklibs}-F /System/Library/PrivateFrameworks -framework CoreSymbolication")
 endif(APPLE)
 
 add_subdirectory(utils)


### PR DESCRIPTION
CMake versions 2.4 and below silently removed leading and trailing
whitespace from libraries linked with code. This was raising an error
for newer CMake versions, according to new CMake policy CMP004
<https://cmake.org/cmake/help/v3.0/policy/CMP0004.html>