### PR TITLE
Fix TMVA notebooks, parallelize notebooks

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -8,6 +8,7 @@ export DOXYGEN_ROOT_VERSION := $(shell root -l -b -q -e 'printf("%s\n", gROOT->G
 export DOXYGEN_EXAMPLE_PATH := $(DOXYGEN_OUTPUT_DIRECTORY)/macros
 export DOXYGEN_IMAGE_PATH := $(DOXYGEN_OUTPUT_DIRECTORY)/html
 export DOXYGEN_NOTEBOOK_PATH := $(DOXYGEN_OUTPUT_DIRECTORY)/notebooks
+export DOXYGEN_NOTEBOOK_PATH_PARALLEL := $(DOXYGEN_NOTEBOOK_PATH)/parallel
 export DOXYGEN_STRIP_PATH := $(shell cd $(PWD)/../..; pwd)
 export DOXYGEN_INCLUDE_PATH := $(shell find $(DOXYGEN_STRIP_PATH) -type d -name dictpch -prune -o -type d -name inc)
 
@@ -32,6 +33,8 @@ doxygen: filter
 	$(call MkDir,$(DOXYGEN_OUTPUT_DIRECTORY))
 	$(call MkDir,$(DOXYGEN_EXAMPLE_PATH))
 	$(call MkDir,$(DOXYGEN_NOTEBOOK_PATH))
+	$(call MkDir,$(DOXYGEN_NOTEBOOK_PATH_PARALLEL))
+	time python ./parallelNotebooks.py
 	./makehtmlfooter.sh > htmlfooter.html
 	doxygen
 	rm -rf files c1* *.ps *.png *.svg *.pdf *.root *.xpm *.out *.dat

--- a/documentation/doxygen/converttonotebook.py
+++ b/documentation/doxygen/converttonotebook.py
@@ -630,7 +630,7 @@ def isCpp():
 def findTimeout():
    listLongtutorials = ["OneSidedFrequentistUpperLimitWithBands", "StandardBayesianNumericalDemo",
    "TwoSidedFrequentistUpperLimitWithBands" , "HybridStandardForm", "rs401d_FeldmanCousins",
-   "TMVAMultipleBackgroundExample", "TMVARegression"]
+   "TMVAMultipleBackgroundExample", "TMVARegression", "TMVAClassification"]
    if tutName in listLongtutorials:
       return 300
    else:
@@ -753,7 +753,7 @@ def mainfunction(text):
     if r != 0:
         sys.stderr.write("NOTEBOOK_CONVERSION_WARNING: Nbconvert failed for notebook %s with return code %s\n" %(outname,r))
     if isJsroot:
-        subprocess.call(["jupyter", "trust",  os.path.join(outdir + outnameconverted)])
+        subprocess.call(["jupyter", "trust",  os.path.join(outdir, outnameconverted)])
     if r == 0:  # Only remove notebook without output if nbconvert succeedes 
         os.remove(outPathName)
 

--- a/documentation/doxygen/parallelNotebooks.py
+++ b/documentation/doxygen/parallelNotebooks.py
@@ -1,0 +1,71 @@
+try:
+    import dagger
+    from joblib import Parallel, delayed
+    import subprocess
+    import multiprocessing
+    import os
+
+    outDir = os.environ["DOXYGEN_NOTEBOOK_PATH_PARALLEL"]
+
+    inputs = subprocess.check_output(["grep",  "-r",  "-l", "/// \\\\notebook\|## \\\\notebook",  os.path.expandvars("$ROOTSYS/tutorials")]).split()
+
+    dependenciesgraph = dagger.dagger()
+
+    for element in inputs:
+        dependenciesgraph.add(element)
+
+    def root(tutName):
+        return os.path.expandvars("$ROOTSYS/tutorials/")+tutName
+
+    dependenciesgraph.add(root("math/testUnfold5d.C"),[root("math/testUnfold5c.C")])
+    dependenciesgraph.add(root("math/testUnfold5c.C"),[root("math/testUnfold5b.C")])
+    dependenciesgraph.add(root("math/testUnfold5b.C"),[root("math/testUnfold5a.C")])
+    dependenciesgraph.add(root("xml/xmlreadfile.C"),[root("xml/xmlnewfile.C")])
+    dependenciesgraph.add(root("roofit/rf503_wspaceread.C"),[root("roofit/rf502_wspacewrite.C")])
+    dependenciesgraph.add(root("io/readCode.C"),[root("io/importCode.C")])
+    dependenciesgraph.add(root("fit/fit1.C"),[root("hist/fillrandom.C")])
+    dependenciesgraph.add(root("fit/myfit.C"),[root("fit/fitslicesy.C")])
+    dependenciesgraph.add(root("foam/foam_demopers.C"),[root("foam/foam_demo.C")])
+    dependenciesgraph.add(root("tree/staff.C"),[root("tree/cernbuild.C")])
+    dependenciesgraph.add(root("tree/cernstaff.C"),[root("tree/cernbuild.C")])
+    dependenciesgraph.add(root("hist/hbars.C"),[root("tree/cernbuild.C")])
+    dependenciesgraph.add(root("pyroot/ntuple.py"),[root("pyroot/hsimple.py")])
+    dependenciesgraph.add(root("pyroot/h1draw.py"),[root("pyroot/hsimple.py")])
+    dependenciesgraph.add(root("pyroot/fit1.py"),[root("pyroot/fillrandom.py")])
+    dependenciesgraph.add(root("tmva/TMVAClassificationApplication.C"),[root("tmva/TMVAClassification.C")])
+    dependenciesgraph.add(root("tmva/TMVAClassificationCategory.C"),[root("tmva/TMVAClassification.C")])
+    dependenciesgraph.add(root("tmva/TMVAClassificationCategoryApplication.C"),[root("tmva/TMVAClassificationCategor")])
+    dependenciesgraph.add(root("tmva/TMVAMulticlass.C"),[root("tmva/TMVAMultipleBackgroundExample.C")])
+    dependenciesgraph.add(root("tmva/TMVAMulticlassApplication.C"),[root("tmva/TMVAMulticlass.C")])
+    dependenciesgraph.add(root("tmva/TMVARegressionApplication.C"),[root("tmva/TMVARegression.C")])
+
+    for node in dependenciesgraph.nodes:
+        dependenciesgraph.stale(node)
+
+    dependenciesgraph.run()
+
+    iterator = dependenciesgraph.iter()
+
+    newinputs = []
+    while len(iterator)>0:
+        todo = iterator.next(10000)
+        newinputs.append(todo)
+        # print todo
+        for element in todo:
+            iterator.remove(element)
+
+    for i in newinputs:
+        print i
+
+    def processInput(inputFile):
+        subprocess.call(['python', './converttonotebook.py', inputFile, outDir])
+    num_cores = multiprocessing.cpu_count()
+
+    def parallel(input):
+        Parallel(n_jobs=num_cores,verbose=100)(delayed(processInput)(i) for i in input)
+
+    for input in newinputs:
+        parallel(input)
+
+except:
+    pass

--- a/tutorials/tmva/TMVAClassificationCategory.C
+++ b/tutorials/tmva/TMVAClassificationCategory.C
@@ -87,7 +87,7 @@ void TMVAClassificationCategory()
    // Load the signal and background event samples from ROOT trees
    TFile *input(0);
    TString fname = TString(gSystem->DirName(__FILE__) ) + "/data/";
-   if (gSystem->AccessPathName( fname )) {
+   if (gSystem->AccessPathName( fname + "toy_sigbkg_categ_offset.root")) {
       // if directory data not found try using tutorials dir
       fname = TString(gROOT->GetTutorialsDir()) + "/tmva/data/";
    }

--- a/tutorials/tmva/TMVAClassificationCategoryApplication.C
+++ b/tutorials/tmva/TMVAClassificationCategoryApplication.C
@@ -84,7 +84,7 @@ void TMVAClassificationCategoryApplication()
    //
    TString fname = TString(gSystem->DirName(__FILE__) ) + "/data/";
    // if directory data not found try using tutorials dir
-   if (gSystem->AccessPathName( fname )) {
+   if (gSystem->AccessPathName( fname + "toy_sigbkg_categ_offset.root"  )) {
       fname = TString(gROOT->GetTutorialsDir()) + "/tmva/data/";
    }
    if (UseOffsetMethod) fname += "toy_sigbkg_categ_offset.root";


### PR DESCRIPTION
TMVA notebooks were fixed. A script that creates the notebooks in parallel is introduced. Note that as of this commit the notebooks are being created twice, the old way via the doxygen filter, and the new parallel way. Once it is ensured that this method works, the old method will be removed. The command for running the script was placed in the doxygen target because if it was made its own target, the necessary folders would not have been created yet.