### PR TITLE
Update basket optimization

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6582,9 +6582,10 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
          UInt_t newBsize = UInt_t(bsize);
          if (pass) { // only on the second pass so that it doesn't interfere with scaling
             if (branch->GetBasket(0) != 0) {
-               newBsize = newBsize + (branch->GetBasket(0)->GetNevBuf() * sizeof(Int_t) * 2); // make room for meta dat
+               newBsize = newBsize + (branch->GetBasket(0)->GetNevBuf() * sizeof(Int_t) * 2); // make room for meta data
             }
-            newBsize = newBsize - newBsize%512 + 512; // rounds up
+            // rounds up, increases basket size to ensure all entries fit into single basket as intended
+            newBsize = newBsize - newBsize%512 + 512;
          }
          if (newBsize < sizeOfOneEntry) newBsize = sizeOfOneEntry;
          if (newBsize < bmin) newBsize = bmin;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -6580,7 +6580,12 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
          if (bsize < 0) bsize = bmax;
          if (bsize > bmax) bsize = bmax;
          UInt_t newBsize = UInt_t(bsize);
-         newBsize = newBsize - newBsize%512;
+         if (pass) { // only on the second pass so that it doesn't interfere with scaling
+            if (branch->GetBasket(0) != 0) {
+               newBsize = newBsize + (branch->GetBasket(0)->GetNevBuf() * sizeof(Int_t) * 2); // make room for meta dat
+            }
+            newBsize = newBsize - newBsize%512 + 512; // rounds up
+         }
          if (newBsize < sizeOfOneEntry) newBsize = sizeOfOneEntry;
          if (newBsize < bmin) newBsize = bmin;
          if (newBsize > 10000000) newBsize = bmax;


### PR DESCRIPTION
This is work done by Alex Saperstein, and ANL SULI who worked with me.

While working on TTreeCache learning, our Summer Intern (Alex Saperstein) observed that for simple TTrees, the basket size optimization isn’t optimal for two reasons: 1) rounding down to 512 byte blocks 2) neglecting to accommodate for ROOT offsets stored in the baskets. As a result, e.g. with simple (constant size) float array branches the basket size is to small resulting in two baskets per auto-flush. The change would be pretty straight-forward: tree/tree/src/TTree.cxx

Line
-6583          newBsize = newBsize - newBsize%512;
 
Should become:
+6583          if (pass) { // only on the second pass so that it doesn't interfere with scaling
+6583             Int_t nevbuf = branch->GetBasket(0)->GetNevBuf();
+6583             newBsize = newBsize + (nevbuf * sizeof(Int_t) * 2); // make room for meta data
+6583             newBsize = newBsize - newBsize%512 + 512; // rounds up
+6583          }
 
Tests on simple data show that with this the baskets end up more appropriately sized so that all the auto-flush data fits.