### PR TITLE
Put definitions of R__unlikely / R__likely in a common place.

### DIFF
--- a/core/base/inc/RConfig.h
+++ b/core/base/inc/RConfig.h
@@ -471,4 +471,27 @@
 #define R__FAST_MATH
 #endif
 
+/*---- unlikely / likely expressions -----------------------------------------*/
+// These are meant to use in cases like:
+//   if (R__unlikely(expression)) { ... }
+// in performance-critical sessions.  R__unlikely / R__likely provide hints to
+// the compiler code generation to heavily optimize one side of a conditional,
+// causing the other branch to have a heavy performance cost.
+//
+// It is best to use this for conditionals that test for rare error cases or
+// backward compatibility code.
+
+#if (__GNUC__ >= 3) || defined(__INTEL_COMPILER)
+#if !defined(R__unlikely)
+  #define R__unlikely(expr) __builtin_expect(!!(expr), 0)
+#endif
+#if !defined(R__likely)
+  #define R__likely(expr) __builtin_expect(!!(expr), 1)
+#endif
+#else
+  #define R__unlikely(expr) expr
+  #define R__likely(expr) expr
+#endif
+
+
 #endif

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -23,19 +23,6 @@
 #include "TTimeStamp.h"
 #include "RZip.h"
 
-// TODO: Copied from TBranch.cxx
-#if (__GNUC__ >= 3) || defined(__INTEL_COMPILER)
-#if !defined(R__unlikely)
-  #define R__unlikely(expr) __builtin_expect(!!(expr), 0)
-#endif
-#if !defined(R__likely)
-  #define R__likely(expr) __builtin_expect(!!(expr), 1)
-#endif
-#else
-  #define R__unlikely(expr) expr
-  #define R__likely(expr) expr
-#endif
-
 const UInt_t kDisplacementMask = 0xFF000000;  // In the streamer the two highest bytes of
                                               // the fEntryOffset are used to stored displacement.
 

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -47,18 +47,6 @@
 
 Int_t TBranch::fgCount = 0;
 
-#if (__GNUC__ >= 3) || defined(__INTEL_COMPILER)
-#if !defined(R__unlikely)
-  #define R__unlikely(expr) __builtin_expect(!!(expr), 0)
-#endif
-#if !defined(R__likely)
-  #define R__likely(expr) __builtin_expect(!!(expr), 1)
-#endif
-#else
-  #define R__unlikely(expr) expr
-  #define R__likely(expr) expr
-#endif
-
 /** \class TBranch
 \ingroup tree
 

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -50,18 +50,6 @@ A Branch for the case of an object.
 
 ClassImp(TBranchElement)
 
-#if (__GNUC__ >= 3) || defined(__INTEL_COMPILER)
-#if !defined(R__unlikely)
-#define R__unlikely(expr) __builtin_expect(!!(expr), 0)
-#endif
-#if !defined(R__likely)
-#define R__likely(expr) __builtin_expect(!!(expr), 1)
-#endif
-#else
-#define R__unlikely(expr) expr
-#define R__likely(expr) expr
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 
 namespace {


### PR DESCRIPTION
@pcanal - this is the refactoring you requested in #240 

Since it's now more visible, I also added a few small comments in `RConfig.h` about when these macros should be utilized.