### PR TITLE
Adding an option to TMVA/BDT to avoid the normalization of weights at boost procedure which was introduced in TMVA 4.1.2

### DIFF
--- a/tmva/tmva/inc/TMVA/MethodBDT.h
+++ b/tmva/tmva/inc/TMVA/MethodBDT.h
@@ -270,6 +270,8 @@ namespace TMVA {
       
       Bool_t                           fDoPreselection;  // do or do not perform automatic pre-selection of 100% eff. cuts
 
+      Bool_t                           fSkipNormalization; // true for skipping normalization at initialization of trees
+
       std::vector<Double_t>            fVariableImportance; // the relative importance of the different variables
 
 

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -202,6 +202,7 @@ TMVA::MethodBDT::MethodBDT( const TString& jobName,
    , fCtb_ss(0)
    , fCbb(0)
    , fDoPreselection(kFALSE)
+   , fSkipNormalization(kFALSE)
    , fHistoricBool(kFALSE) 
 {
    fMonitorNtuple = NULL;
@@ -255,6 +256,7 @@ TMVA::MethodBDT::MethodBDT( DataSetInfo& theData,
    , fCtb_ss(0)
    , fCbb(0)
    , fDoPreselection(kFALSE)
+   , fSkipNormalization(kFALSE)
    , fHistoricBool(kFALSE) 
 {
    fMonitorNtuple = NULL;
@@ -312,7 +314,10 @@ Bool_t TMVA::MethodBDT::HasAnalysisType( Types::EAnalysisType type, UInt_t numbe
 ///                         DecreaseBoostWeight     Boost ev. with neg. weight with 1/boostweight instead of boostweight
 ///                         PairNegWeightsGlobal    Pair ev. with neg. and pos. weights in traning sample and "annihilate" them 
 /// MaxDepth         maximum depth of the decision tree allowed before further splitting is stopped
+/// SkipNormalization	    Skip normalization at initialization, to keep expectation value of BDT output
+///			    according to the fraction of events
 
+ 
 void TMVA::MethodBDT::DeclareOptions()
 {
    DeclareOptionRef(fNTrees, "NTrees", "Number of trees in the forest");
@@ -411,7 +416,9 @@ void TMVA::MethodBDT::DeclareOptions()
 
    DeclareOptionRef(fFValidationEvents=0.5, "PruningValFraction", "Fraction of events to use for optimizing automatic pruning.");
 
-   // deprecated options, still kept for the moment:
+   DeclareOptionRef(fSkipNormalization=kFALSE, "SkipNormalization", "Skip normalization at initialization, to keep expectation value of BDT output according to the fraction of events");
+
+    // deprecated options, still kept for the moment:
    DeclareOptionRef(fMinNodeEvents=0, "nEventsMin", "deprecated: Use MinNodeSize (in % of training events) instead");
 
    DeclareOptionRef(fBaggedGradBoost=kFALSE, "UseBaggedGrad","deprecated: Use *UseBaggedBoost* instead:  Use only a random subsample of all events for growing the trees in each iteration.");
@@ -814,7 +821,7 @@ void TMVA::MethodBDT::InitEventSample( void )
       if (fPairNegWeightsGlobal) PreProcessNegativeEventWeights();
    }
 
-   if (!DoRegression()){
+   if (!DoRegression() && !fSkipNormalization){
       Log() << kDEBUG << "\t<InitEventSample> For classification trees, "<< Endl;
       Log() << kDEBUG << " \tthe effective number of backgrounds is scaled to match "<<Endl;
       Log() << kDEBUG << " \tthe signal. Otherwise the first boosting step would do 'just that'!"<<Endl;


### PR DESCRIPTION
We are working on LCFIPlus, a flavor tagging software used for linear collider (ILC/CLIC) studies.
We use multi-class BDT with output of b-tag, c-tag, and uds-tag (3 outputs).
We also separate events into four categories according to number of reconstructed vertices
(0-vtx, 1-vtx, 1-vtx+1-partial-vtx, and 2-vtx) which are trained and evaluated independently.
In the previous release with TMVA 4.1.0 we can use the output of BDTs as variables common to 
all categories, because the average value of eg. b-tag output from each BDT
over full training samples reflects the fraction of b events in the training samples.
(eg. if we have 80% of b and 20% of c + uds, we have the avarage value of .8 for b-tag output.)
We found this feature is not preserved in the latest releases (after TMVA 4.1.2)
due to the normalization procedure introduced in that version.
In result this causes significant degradation of our flavor tagging performance,
which was reported from a user using latest ROOT/TMVA.
We also found that just switching off the normalization procedure in the ROOT 6.06/TMVA 4.2.1
gives very similar performance to the ROOT 5.28/TMVA 4.1.0.
Therefore, we need to switch off the normalization to keep the performance,
which is realized in an option implemented in this pull request.
We hope this will be accepted, to avoid us from patching this to every release of ROOT
we use for studies using LCFIPlus flavor tagging feature.
We set this option to non-default, so current users should not be affected by this change.
![btag-100k-root-6 06 02-skipnorm](https://cloud.githubusercontent.com/assets/7939934/18453216/0f501eb0-78f3-11e6-892c-912f9b68553d.png)
B-tag performance with the SkipNormalization option
![btag-100k-root-6 06 02-noskipnorm](https://cloud.githubusercontent.com/assets/7939934/18453215/0f4e6b60-78f3-11e6-94bd-b4be9631937d.png)
B-tag performance without the SkipNormalization option
