### PR TITLE
Properly reset terminal state for various obscure signals.

### DIFF
--- a/core/textinput/src/textinput/TerminalConfigUnix.cpp
+++ b/core/textinput/src/textinput/TerminalConfigUnix.cpp
@@ -44,7 +44,11 @@ const int TerminalConfigUnix::fgSignals[kNumHandledSignals] = {
   SIGABRT,
   SIGSEGV,
   SIGILL,
-  SIGBUS
+  SIGBUS,
+  SIGQUIT,
+  SIGFPE,
+  SIGXCPU,
+  SIGXFSZ
 };
 
 TerminalConfigUnix&

--- a/core/textinput/src/textinput/TerminalConfigUnix.h
+++ b/core/textinput/src/textinput/TerminalConfigUnix.h
@@ -56,7 +56,7 @@ private:
 
   bool fIsAttached; // whether fConfTIOS is active.
   int fFD; // file descriptor
-  enum { kNumHandledSignals = 5 }; // number of fPrevHandler entries
+  enum { kNumHandledSignals = 9 }; // number of fPrevHandler entries
   static const int
     fgSignals[kNumHandledSignals]; // signal nums, order as in fPrevHandler
   sig_t fPrevHandler[kNumHandledSignals]; // next signal handler to call


### PR DESCRIPTION
When testing the refactored signal handler, I noticed that a few obscure (but not impossible!) Unix signals cause ROOT to exit without reseting the TTY state back to its original state.

This PR simply adds a few extra signals to `TerminalConfigUnix` and bumps the signal count as appropriate.