### PR TITLE
Remove wrong and redundant null pointer check

### DIFF
--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -111,9 +111,7 @@ TEnum *TEnum::GetEnum(const std::type_info &ti, ESearchAction sa)
    char *demangledEnumName = TClassEdit::DemangleName(ti.name(), errorCode);
 
    if (errorCode != 0) {
-      if (!demangledEnumName) {
-         free(demangledEnumName);
-      }
+      free(demangledEnumName);
       std::cerr << "ERROR TEnum::GetEnum - A problem occurred while demangling name.\n";
       return nullptr;
    }


### PR DESCRIPTION
I think `if (demangledEnumName)` was meant here, but it is redundant, because behaviour of `free`ing a null pointer is defined and it is no-op.