### PR TITLE
Remove redundant null pointer check

### DIFF
--- a/proof/proof/src/TProof.cxx
+++ b/proof/proof/src/TProof.cxx
@@ -1363,7 +1363,7 @@ Int_t TProof::AddWorkers(TList *workerList)
       // Remove worker from the list of workers terminated gracefully
       dummysi->SetOrdinal(fullord);
       TSlaveInfo *rmsi = (TSlaveInfo *)fTerminatedSlaveInfos->Remove(dummysi);
-      if (rmsi) SafeDelete(rmsi);
+      SafeDelete(rmsi);
 
       // Create worker server
       TString wn(worker->GetNodeName());


### PR DESCRIPTION
Sed [SafeDelete definition](https://github.com/root-mirror/root/blob/edfa4cc5d8c02c626dbc3f0e9283f8fd9b28698b/core/base/inc/RConfig.h#L465)

It seem that new static analyzer exhumes lots of ancient sh*t. Do I (we) need to give attention to such cases?

And it seem that this repository is missing the "Issues" tab. I have some interesting places and I'm not sure how to fix them.