### PR TITLE
Fix condition which was incorrect due to operator precedence

### DIFF
--- a/net/net/src/TParallelMergingFile.cxx
+++ b/net/net/src/TParallelMergingFile.cxx
@@ -120,7 +120,9 @@ Bool_t TParallelMergingFile::UploadAndReset()
    fMessage.WriteLong64(GetEND());
    CopyTo(fMessage);
 
-   if (int error = fSocket->Send(fMessage) <= 0) {
+   // FIXME: CXX17: Use init-statement in if to declare `error` variable
+   int error;
+   if ((error = fSocket->Send(fMessage)) <= 0) {
       Error("UploadAndReset","Upload to the merging server failed with %d\n",error);
       delete fSocket;
       fSocket = 0;


### PR DESCRIPTION
`int error = fSocket->Send(fMessage) <= 0` is evaluated as 
`int error = (fSocket->Send(fMessage) <= 0)` and not as
`(int error = fSocket->Send(fMessage)) <= 0`