### PR TITLE
missing include

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/DataLoader.h
@@ -21,6 +21,7 @@
 #include "TMatrix.h"
 #include <vector>
 #include <iostream>
+#include <algorithm>
 
 #include "TMVA/Event.h"
 


### PR DESCRIPTION
Missing include for std::random_shuffle.
