### PR TITLE
[TMVA] cmake status message if PyMVA is dropped due to missing numpy

### DIFF
--- a/tmva/CMakeLists.txt
+++ b/tmva/CMakeLists.txt
@@ -1,8 +1,9 @@
-
 add_subdirectory(tmva)
 add_subdirectory(tmvagui)
 if(python AND NUMPY_FOUND)
    add_subdirectory(pymva)
+elseif(python AND NOT NUMPY_FOUND)
+   message(STATUS "TMVA: Deactivate PyMVA because numpy is not found")
 endif()
 if(r)
 add_subdirectory(rmva)


### PR DESCRIPTION
Print status message during cmake if PyMVA is not build and python is activated but numpy is not found. Otherwise, a missing numpy drops PyMVA silently (and confuses the user).