### PR TITLE
[TMVA] Add dataloader option `TrainTestSplit_<class>`

### DIFF
--- a/tmva/tmva/inc/TMVA/DataSetFactory.h
+++ b/tmva/tmva/inc/TMVA/DataSetFactory.h
@@ -219,6 +219,7 @@ namespace TMVA {
       public:
          Int_t    nTrainingEventsRequested;
          Int_t    nTestingEventsRequested;
+         Float_t  TrainTestSplitRequested;
          Int_t    nInitialEvents;
          Int_t    nEvBeforeCut;
          Int_t    nEvAfterCut;
@@ -229,6 +230,7 @@ namespace TMVA {
       EventStats():
          nTrainingEventsRequested(0),
             nTestingEventsRequested(0),
+            TrainTestSplitRequested(0),
             nInitialEvents(0),
             nEvBeforeCut(0),
             nEvAfterCut(0),


### PR DESCRIPTION
Note: If this option is set, it will override the `nTrain_<class>` and `nTest_<class>` options.