### PR TITLE
First-pass IMT implementation of FlushBaskets.

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -50,6 +50,11 @@ class TFilePrefetch;
 class TFile : public TDirectoryFile {
   friend class TDirectoryFile;
   friend class TFilePrefetch;
+// TODO: We need to make sure only one TBasket is being written at a time
+// if we are writing multiple baskets in parallel.
+#ifdef R__USE_IMT
+  friend class TBasket;
+#endif
 
 public:
    /// Asynchronous open request status
@@ -106,6 +111,7 @@ protected:
 
 #ifdef R__USE_IMT
    static ROOT::TRWSpinLock fgRwLock;    ///<!Read-write lock to protect global PID list
+   std::mutex               fWriteMutex; ///<!Lock for writing baskets / keys into the file.
 #endif
 
    static TList    *fgAsyncOpenRequests; //List of handles for pending open requests

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -37,6 +37,8 @@
 #endif
 #endif
 
+#include <mutex>
+
 class TFree;
 class TArrayC;
 class TArchiveFile;

--- a/test/MainEvent.cxx
+++ b/test/MainEvent.cxx
@@ -108,6 +108,7 @@ int main(int argc, char **argv)
    Int_t read   = 0;
    Int_t arg4   = 1;
    Int_t arg5   = 600;     //default number of tracks per event
+   Int_t enable_imt = 0;   // Whether to enable IMT mode.
    Int_t netf   = 0;
    Int_t punzip = 0;
 
@@ -116,6 +117,7 @@ int main(int argc, char **argv)
    if (argc > 3)  split  = atoi(argv[3]);
    if (argc > 4)  arg4   = atoi(argv[4]);
    if (argc > 5)  arg5   = atoi(argv[5]);
+   if (argc > 6)  enable_imt = atoi(argv[6]);
    if (arg4 ==  0) { write = 0; hfill = 0; read = 1;}
    if (arg4 ==  1) { write = 1; hfill = 0;}
    if (arg4 ==  2) { write = 0; hfill = 0;}
@@ -130,6 +132,18 @@ int main(int argc, char **argv)
    if (arg4 == 36) { write = 1; }            //netfile + write sequential
    Int_t branchStyle = 1; //new style by default
    if (split < 0) {branchStyle = 0; split = -1-split;}
+
+#ifdef R__USE_IMT
+   if (enable_imt) {
+     ROOT::EnableImplicitMT();
+   }
+#else
+   if (enable_imt) {
+     std::cerr << "IMT mode requested, but this version of ROOT "
+                  "is built without IMT support." << std::endl;
+     return 1;
+   }
+#endif
 
    TFile *hfile;
    TTree *tree;
@@ -258,7 +272,7 @@ int main(int argc, char **argv)
       printf("You read %f Mbytes/Realtime seconds\n",mbytes/rtime);
       printf("You read %f Mbytes/Cputime seconds\n",mbytes/ctime);
    } else {
-      printf("compression level=%d, split=%d, arg4=%d\n",comp,split,arg4);
+      printf("compression level=%d, split=%d, arg4=%d, IMT=%d\n",comp,split,arg4, enable_imt);
       printf("You write %f Mbytes/Realtime seconds\n",mbytes/rtime);
       printf("You write %f Mbytes/Cputime seconds\n",mbytes/ctime);
       //printf("file compression factor = %f\n",hfile.GetCompressionFactor());

--- a/test/MainEvent.cxx
+++ b/test/MainEvent.cxx
@@ -131,12 +131,9 @@ int main(int argc, char **argv)
    Int_t branchStyle = 1; //new style by default
    if (split < 0) {branchStyle = 0; split = -1-split;}
 
-   ROOT::EnableImplicitMT(4);
-
    TFile *hfile;
    TTree *tree;
    Event *event = 0;
-   Event *event2 = 0;
 
    // Fill event, header and tracks with some random numbers
    //   Create a timer object to benchmark this loop
@@ -198,7 +195,6 @@ int main(int argc, char **argv)
       } else
          hfile = new TFile("Event.root","RECREATE","TTree benchmark ROOT file");
       hfile->SetCompressionLevel(comp);
-      //hfile->SetCompressionAlgorithm(2);
 
      // Create histogram to show write_time in function of time
      Float_t curtime = -0.5;
@@ -217,16 +213,9 @@ int main(int argc, char **argv)
       bufsize = 64000;
       if (split)  bufsize /= 4;
       event = new Event();           // By setting the value, we own the pointer and must delete it.
-      event2 = new Event();           // By setting the value, we own the pointer and must delete it.
       TTree::SetBranchStyle(branchStyle);
       TBranch *branch = tree->Branch("event", &event, bufsize,split);
-      TBranch *branch2 = tree->Branch("event2", &event, bufsize,split);
-      TBranch *branch3 = tree->Branch("event3", &event2, bufsize,split);
-      TBranch *branch4 = tree->Branch("event4", &event2, bufsize,split);
       branch->SetAutoDelete(kFALSE);
-      branch2->SetAutoDelete(kFALSE);
-      branch3->SetAutoDelete(kFALSE);
-      branch4->SetAutoDelete(kFALSE);
       if(split >= 0 && branchStyle) tree->BranchRef();
       Float_t ptmin = 1;
 
@@ -241,7 +230,6 @@ int main(int argc, char **argv)
          }
 
          event->Build(ev, arg5, ptmin);
-         event2->Build(ev, arg5, ptmin);
 
          if (write) nb += tree->Fill();  //fill the tree
 
@@ -254,8 +242,7 @@ int main(int argc, char **argv)
       }
    }
    // We own the event (since we set the branch address explicitly), we need to delete it.
-   // delete event;  event = 0;
-   // delete event2;  event2 = 0;
+   delete event;  event = 0;
 
    //  Stop timer and print results
    timer.Stop();

--- a/test/MainEvent.cxx
+++ b/test/MainEvent.cxx
@@ -131,9 +131,12 @@ int main(int argc, char **argv)
    Int_t branchStyle = 1; //new style by default
    if (split < 0) {branchStyle = 0; split = -1-split;}
 
+   ROOT::EnableImplicitMT(4);
+
    TFile *hfile;
    TTree *tree;
    Event *event = 0;
+   Event *event2 = 0;
 
    // Fill event, header and tracks with some random numbers
    //   Create a timer object to benchmark this loop
@@ -195,6 +198,7 @@ int main(int argc, char **argv)
       } else
          hfile = new TFile("Event.root","RECREATE","TTree benchmark ROOT file");
       hfile->SetCompressionLevel(comp);
+      //hfile->SetCompressionAlgorithm(2);
 
      // Create histogram to show write_time in function of time
      Float_t curtime = -0.5;
@@ -213,9 +217,16 @@ int main(int argc, char **argv)
       bufsize = 64000;
       if (split)  bufsize /= 4;
       event = new Event();           // By setting the value, we own the pointer and must delete it.
+      event2 = new Event();           // By setting the value, we own the pointer and must delete it.
       TTree::SetBranchStyle(branchStyle);
       TBranch *branch = tree->Branch("event", &event, bufsize,split);
+      TBranch *branch2 = tree->Branch("event2", &event, bufsize,split);
+      TBranch *branch3 = tree->Branch("event3", &event2, bufsize,split);
+      TBranch *branch4 = tree->Branch("event4", &event2, bufsize,split);
       branch->SetAutoDelete(kFALSE);
+      branch2->SetAutoDelete(kFALSE);
+      branch3->SetAutoDelete(kFALSE);
+      branch4->SetAutoDelete(kFALSE);
       if(split >= 0 && branchStyle) tree->BranchRef();
       Float_t ptmin = 1;
 
@@ -230,6 +241,7 @@ int main(int argc, char **argv)
          }
 
          event->Build(ev, arg5, ptmin);
+         event2->Build(ev, arg5, ptmin);
 
          if (write) nb += tree->Fill();  //fill the tree
 
@@ -242,7 +254,8 @@ int main(int argc, char **argv)
       }
    }
    // We own the event (since we set the branch address explicitly), we need to delete it.
-   delete event;  event = 0;
+   // delete event;  event = 0;
+   // delete event2;  event2 = 0;
 
    //  Stop timer and print results
    timer.Stop();

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -163,11 +163,11 @@ private:
    TTree(const TTree& tt);              // not implemented
    TTree& operator=(const TTree& tt);   // not implemented
 
-#ifdef R__USE_IMT
+   // For simplicity, although fIMTFlush is always disabled in non-IMT builds, we don't #ifdef it out.
    mutable Bool_t fIMTFlush{false};               ///<! True if we are doing a multithreaded flush.
    mutable std::atomic<Long64_t> fIMTTotBytes;    ///<! Total bytes for the IMT flush baskets
    mutable std::atomic<Long64_t> fIMTZipBytes;    ///<! Zip bytes for the IMT flush baskets.
-#endif
+
    void             InitializeSortedBranches();
    void             SortBranchesByTime();
 

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -164,7 +164,9 @@ private:
    TTree& operator=(const TTree& tt);   // not implemented
 
 #ifdef R__USE_IMT
-   mutable std::mutex fCounterMutex;      ///<!Lock to protect counters
+   mutable Bool_t fIMTFlush{false};               ///<! True if we are doing a multithreaded flush.
+   mutable std::atomic<Long64_t> fIMTTotBytes;    ///<! Total bytes for the IMT flush baskets
+   mutable std::atomic<Long64_t> fIMTZipBytes;    ///<! Zip bytes for the IMT flush baskets.
 #endif
    void             InitializeSortedBranches();
    void             SortBranchesByTime();
@@ -309,8 +311,10 @@ public:
    virtual TFriendElement *AddFriend(const char* treename, const char* filename = "");
    virtual TFriendElement *AddFriend(const char* treename, TFile* file);
    virtual TFriendElement *AddFriend(TTree* tree, const char* alias = "", Bool_t warn = kFALSE);
-   virtual void            AddTotBytes(Int_t tot) { std::lock_guard<std::mutex> sentry(fCounterMutex); fTotBytes += tot; }
-   virtual void            AddZipBytes(Int_t zip) { std::lock_guard<std::mutex> sentry(fCounterMutex); fZipBytes += zip; }
+   // As the TBasket invokes Add{Tot,Zip}Bytes on its parent tree, we must do these updates in a thread-safe
+   // manner only when we are flushing multiple baskets in parallel.
+   virtual void            AddTotBytes(Int_t tot) { if (fIMTFlush) { fIMTTotBytes += tot; } else { fTotBytes += tot; } }
+   virtual void            AddZipBytes(Int_t zip) { if (fIMTFlush) { fIMTZipBytes += zip; } else { fZipBytes += zip; } }
    virtual Long64_t        AutoSave(Option_t* option = "");
    virtual Int_t           Branch(TCollection* list, Int_t bufsize = 32000, Int_t splitlevel = 99, const char* name = "");
    virtual Int_t           Branch(TList* list, Int_t bufsize = 32000, Int_t splitlevel = 99);
@@ -445,7 +449,7 @@ public:
    virtual Long64_t        GetSelectedRows() { return GetPlayer()->GetSelectedRows(); }
    virtual Int_t           GetTimerInterval() const { return fTimerInterval; }
            TBuffer*        GetTransientBuffer(Int_t size);
-   virtual Long64_t        GetTotBytes() const { std::lock_guard<std::mutex> sentry(fCounterMutex); return fTotBytes; }
+   virtual Long64_t        GetTotBytes() const { return fTotBytes; }
    virtual TTree          *GetTree() const { return const_cast<TTree*>(this); }
    virtual TVirtualIndex  *GetTreeIndex() const { return fTreeIndex; }
    virtual Int_t           GetTreeNumber() const { return 0; }
@@ -473,7 +477,7 @@ public:
    virtual Double_t       *GetV4()   { return GetPlayer()->GetV4(); }
    virtual Double_t       *GetW()    { return GetPlayer()->GetW(); }
    virtual Double_t        GetWeight() const   { return fWeight; }
-   virtual Long64_t        GetZipBytes() const { std::lock_guard<std::mutex> sentry(fCounterMutex); return fZipBytes; }
+   virtual Long64_t        GetZipBytes() const { return fZipBytes; }
    virtual void            IncrementTotalBuffers(Int_t nbytes) { fTotalBuffers += nbytes; }
    Bool_t                  IsFolder() const { return kTRUE; }
    virtual Int_t           LoadBaskets(Long64_t maxmemory = 2000000000);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -70,7 +70,7 @@
 #include "TVirtualTreePlayer.h"
 #endif
 
-#include <mutex>
+#include <atomic>
 
 class TBranch;
 class TBrowser;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -1336,13 +1336,13 @@ Long64_t TTree::AutoSave(Option_t* option)
 {
    if (!fDirectory || fDirectory == gROOT || !fDirectory->IsWritable()) return 0;
    if (gDebug > 0) {
-      printf("AutoSave Tree:%s after %lld bytes written\n",GetName(),GetTotBytes());
+      Info("AutoSave", "Tree:%s after %lld bytes written\n",GetName(),GetTotBytes());
    }
    TString opt = option;
    opt.ToLower();
 
    if (opt.Contains("flushbaskets")) {
-      if (gDebug > 0) printf("AutoSave:  calling FlushBaskets \n");
+      if (gDebug > 0) Info("AutoSave", "calling FlushBaskets \n");
       FlushBaskets();
    }
 
@@ -3608,7 +3608,7 @@ void TTree::Delete(Option_t* option /* = "" */)
          key = fDirectory->GetKey(GetName());
       }
       if (dirsav) dirsav->cd();
-      if (gDebug) printf(" Deleting Tree: %s: %d baskets deleted. Total space freed = %d bytes\n",GetName(),nbask,ntot);
+      if (gDebug) Info("TTree::Delete", "Deleting Tree: %s: %d baskets deleted. Total space freed = %d bytes\n",GetName(),nbask,ntot);
    }
 
    if (fDirectory) {
@@ -4417,7 +4417,7 @@ Int_t TTree::Fill()
    if (fEntries > fMaxEntries) {
       KeepCircular();
    }
-   if (gDebug > 0) printf("TTree::Fill - A:  %d %lld %lld %lld %lld %lld %lld \n",
+   if (gDebug > 0) Info("TTree::Fill", " - A:  %d %lld %lld %lld %lld %lld %lld \n",
        nbytes, fEntries, fAutoFlush,fAutoSave,GetZipBytes(),fFlushedBytes,fSavedBytes);
 
    if (fAutoFlush != 0 || fAutoSave != 0) {
@@ -6659,7 +6659,7 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
          if (newBsize < bmin) newBsize = bmin;
          if (newBsize > 10000000) newBsize = bmax;
          if (pass) {
-            if (pDebug) printf("Changing buffer size from %6d to %6d bytes for %s\n",oldBsize,newBsize,branch->GetName());
+            if (pDebug) Info("OptimizeBaskets", "Changing buffer size from %6d to %6d bytes for %s\n",oldBsize,newBsize,branch->GetName());
             branch->SetBasketSize(newBsize);
          }
          newMemsize += newBsize;
@@ -6672,7 +6672,7 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
          Double_t comp = 1;
          if (branch->GetZipBytes() > 0) comp = totBytes/Double_t(branch->GetZipBytes());
          if (comp > 1 && comp < minComp) {
-            if (pDebug) printf("Disabling compression for branch : %s\n",branch->GetName());
+            if (pDebug) Info("OptimizeBaskets", "Disabling compression for branch : %s\n",branch->GetName());
             branch->SetCompressionSettings(0);
          }
       }
@@ -6693,8 +6693,8 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
       bmax = (bmax_new > hardmax) ? bmin : (UInt_t)bmax_new;
    }
    if (pDebug) {
-      printf("oldMemsize = %d,  newMemsize = %d\n",oldMemsize, newMemsize);
-      printf("oldBaskets = %d,  newBaskets = %d\n",oldBaskets, newBaskets);
+      Info("OptimizeBaskets", "oldMemsize = %d,  newMemsize = %d\n",oldMemsize, newMemsize);
+      Info("OptimizeBaskets", "oldBaskets = %d,  newBaskets = %d\n",oldBaskets, newBaskets);
    }
 }
 
@@ -6818,7 +6818,7 @@ void TTree::Print(Option_t* option) const
          if (count[l] < 0) continue;
          leaf = (TLeaf *)const_cast<TTree*>(this)->GetListOfLeaves()->At(l);
          br   = leaf->GetBranch();
-         printf("branch: %-20s %9lld\n",br->GetName(),count[l]);
+         Printf("branch: %-20s %9lld\n",br->GetName(),count[l]);
       }
       delete [] count;
    } else {

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -1336,7 +1336,7 @@ Long64_t TTree::AutoSave(Option_t* option)
 {
    if (!fDirectory || fDirectory == gROOT || !fDirectory->IsWritable()) return 0;
    if (gDebug > 0) {
-      printf("AutoSave Tree:%s after %lld bytes written\n",GetName(),fTotBytes);
+      printf("AutoSave Tree:%s after %lld bytes written\n",GetName(),GetTotBytes());
    }
    TString opt = option;
    opt.ToLower();
@@ -1346,7 +1346,7 @@ Long64_t TTree::AutoSave(Option_t* option)
       FlushBaskets();
    }
 
-   fSavedBytes = fZipBytes;
+   fSavedBytes = GetZipBytes();
 
    TKey *key = (TKey*)fDirectory->GetListOfKeys()->FindObject(GetName());
    Long64_t nbytes;
@@ -4418,23 +4418,24 @@ Int_t TTree::Fill()
       KeepCircular();
    }
    if (gDebug > 0) printf("TTree::Fill - A:  %d %lld %lld %lld %lld %lld %lld \n",
-       nbytes, fEntries, fAutoFlush,fAutoSave,fZipBytes,fFlushedBytes,fSavedBytes);
+       nbytes, fEntries, fAutoFlush,fAutoSave,GetZipBytes(),fFlushedBytes,fSavedBytes);
 
    if (fAutoFlush != 0 || fAutoSave != 0) {
       // Is it time to flush or autosave baskets?
       if (fFlushedBytes == 0) {
          // Decision can be based initially either on the number of bytes
          // or the number of entries written.
-         if ((fAutoFlush<0 && fZipBytes > -fAutoFlush)  ||
-             (fAutoSave <0 && fZipBytes > -fAutoSave )  ||
+         Long64_t zipBytes = GetZipBytes();
+         if ((fAutoFlush<0 && zipBytes > -fAutoFlush)  ||
+             (fAutoSave <0 && zipBytes > -fAutoSave )  ||
              (fAutoFlush>0 && fEntries%TMath::Max((Long64_t)1,fAutoFlush) == 0) ||
              (fAutoSave >0 && fEntries%TMath::Max((Long64_t)1,fAutoSave)  == 0) ) {
 
             //First call FlushBasket to make sure that fTotBytes is up to date.
             FlushBaskets();
-            OptimizeBaskets(fTotBytes,1,"");
-            if (gDebug > 0) Info("TTree::Fill","OptimizeBaskets called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,fZipBytes,fFlushedBytes);
-            fFlushedBytes = fZipBytes;
+            OptimizeBaskets(GetTotBytes(),1,"");
+            if (gDebug > 0) Info("TTree::Fill","OptimizeBaskets called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
+            fFlushedBytes = GetZipBytes();
             fAutoFlush    = fEntries;  // Use test on entries rather than bytes
 
             // subsequently in run
@@ -4442,10 +4443,11 @@ Int_t TTree::Fill()
                // Set fAutoSave to the largest integer multiple of
                // fAutoFlush events such that fAutoSave*fFlushedBytes
                // < (minus the input value of fAutoSave)
-               if (fZipBytes != 0) {
-                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/fZipBytes)/fEntries));
-               } else if (fTotBytes != 0) {
-                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/fTotBytes)/fEntries));
+               Long64_t totBytes = GetTotBytes();
+               if (zipBytes != 0) {
+                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/zipBytes)/fEntries));
+               } else if (totBytes != 0) {
+                  fAutoSave =  TMath::Max( fAutoFlush, fEntries*((-fAutoSave/totBytes)/fEntries));
                } else {
                   TBufferFile b(TBuffer::kWrite, 10000);
                   TTree::Class()->WriteBuffer(b, (TTree*) this);
@@ -4462,24 +4464,24 @@ Int_t TTree::Fill()
          if (fAutoSave != 0 && fEntries%fAutoSave == 0) {
             //We are at an AutoSave point. AutoSave flushes baskets and saves the Tree header
             AutoSave("flushbaskets");
-            if (gDebug > 0) Info("TTree::Fill","AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",fEntries,fZipBytes,fSavedBytes);
+            if (gDebug > 0) Info("TTree::Fill","AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",fEntries,GetZipBytes(),fSavedBytes);
          } else {
             //We only FlushBaskets
             FlushBaskets();
-            if (gDebug > 0) Info("TTree::Fill","FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,fZipBytes,fFlushedBytes);
+            if (gDebug > 0) Info("TTree::Fill","FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
          }
-         fFlushedBytes = fZipBytes;
+         fFlushedBytes = GetZipBytes();
       } else if (fNClusterRange == 0 && fEntries > 1 && fAutoFlush && fEntries%fAutoFlush == 0) {
          if (fAutoSave != 0 && fEntries%fAutoSave == 0) {
             //We are at an AutoSave point. AutoSave flushes baskets and saves the Tree header
             AutoSave("flushbaskets");
-            if (gDebug > 0) Info("TTree::Fill","AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",fEntries,fZipBytes,fSavedBytes);
+            if (gDebug > 0) Info("TTree::Fill","AutoSave called at entry %lld, fZipBytes=%lld, fSavedBytes=%lld\n",fEntries,GetZipBytes(),fSavedBytes);
          } else {
             //We only FlushBaskets
             FlushBaskets();
-            if (gDebug > 0) Info("TTree::Fill","FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,fZipBytes,fFlushedBytes);
+            if (gDebug > 0) Info("TTree::Fill","FlushBasket called at entry %lld, fZipBytes=%lld, fFlushedBytes=%lld\n",fEntries,GetZipBytes(),fFlushedBytes);
          }
-         fFlushedBytes = fZipBytes;
+         fFlushedBytes = GetZipBytes();
       }
    }
    // Check that output file is still below the maximum size.
@@ -4802,6 +4804,48 @@ Int_t TTree::FlushBaskets() const
    Int_t nerror = 0;
    TObjArray *lb = const_cast<TTree*>(this)->GetListOfBranches();
    Int_t nb = lb->GetEntriesFast();
+
+#ifdef R__USE_IMT
+   if (ROOT::IsImplicitMTEnabled() && fIMTEnabled) {
+      if (fSortedBranches.empty()) { const_cast<TTree*>(this)->InitializeSortedBranches(); }
+
+      // Enable this IMT use case (activate its locks)
+      ROOT::Internal::TParBranchProcessingRAII pbpRAII;
+
+      std::atomic<Int_t> nerrpar(0);
+      std::atomic<Int_t> nbpar(0);
+      std::atomic<Int_t> pos(0);
+      tbb::task_group g;
+
+      for (Int_t i = 0; i < nb; i++) {
+         g.run([&]() {
+            // The branch to process is obtained when the task starts to run.
+            // This way, since branches are sorted, we make sure that branches
+            // leading to big tasks are processed first. If we assigned the
+            // branch at task creation time, the scheduler would not necessarily
+            // respect our sorting.
+            Int_t j = pos.fetch_add(1);
+
+            auto branch = fSortedBranches[j].second;
+            if (R__unlikely(!branch)) { return; }
+
+            if (R__unlikely(gDebug > 0)) {
+               std::stringstream ss;
+               ss << std::this_thread::get_id();
+               Info("FlushBaskets", "[IMT] Thread %s", ss.str().c_str());
+               Info("FlushBaskets", "[IMT] Running task for branch #%d: %s", j, branch->GetName());
+            }
+
+            Int_t nbtask = branch->FlushBaskets();
+
+            if (nbtask < 0) { nerrpar++; }
+            else            { nbpar += nbtask; }
+         });
+      }
+      g.wait();
+      return nerrpar ? -1 : nbpar.load();
+   }
+#endif
    for (Int_t j = 0; j < nb; j++) {
       TBranch* branch = (TBranch*) lb->UncheckedAt(j);
       if (branch) {
@@ -5006,7 +5050,7 @@ Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ ) const
 
    if (fAutoFlush < 0) cacheSize = Long64_t(-cacheFactor*fAutoFlush);
    else if (fAutoFlush == 0) cacheSize = 0;
-   else cacheSize = Long64_t(cacheFactor*1.5*fAutoFlush*fZipBytes/(fEntries+1));
+   else cacheSize = Long64_t(cacheFactor*1.5*fAutoFlush*GetZipBytes()/(fEntries+1));
 
    if (cacheSize >= (INT_MAX / 4)) {
       cacheSize = INT_MAX / 4;
@@ -5019,7 +5063,7 @@ Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ ) const
    if (cacheSize == 0 && withDefault) {
       if (fAutoFlush < 0) cacheSize = -fAutoFlush;
       else if (fAutoFlush == 0) cacheSize = 0;
-      else cacheSize = Long64_t(1.5*fAutoFlush*fZipBytes/(fEntries+1));
+      else cacheSize = Long64_t(1.5*fAutoFlush*GetZipBytes()/(fEntries+1));
    }
 
    return cacheSize;
@@ -6702,16 +6746,17 @@ void TTree::Print(Option_t* option) const
       }
    }
    Long64_t total = skey;
-   if (fZipBytes > 0) {
-      total += fTotBytes;
+   Long64_t zipBytes = GetZipBytes();
+   if (zipBytes > 0) {
+      total += GetTotBytes();
    }
    TBufferFile b(TBuffer::kWrite, 10000);
    TTree::Class()->WriteBuffer(b, (TTree*) this);
    total += b.Length();
-   Long64_t file = fZipBytes + s;
+   Long64_t file = zipBytes + s;
    Float_t cx = 1;
-   if (fZipBytes) {
-      cx = (fTotBytes + 0.00001) / fZipBytes;
+   if (zipBytes) {
+      cx = (GetTotBytes() + 0.00001) / zipBytes;
    }
    Printf("******************************************************************************");
    Printf("*Tree    :%-10s: %-54s *", GetName(), GetTitle());
@@ -7352,8 +7397,11 @@ void TTree::Refresh()
 
    fAutoSave = tree->fAutoSave;
    fEntries = tree->fEntries;
-   fTotBytes = tree->fTotBytes;
-   fZipBytes = tree->fZipBytes;
+   {
+      std::lock_guard<std::mutex> sentry(fCounterMutex);
+      fTotBytes = tree->GetTotBytes();
+      fZipBytes = tree->GetZipBytes();
+   }
    fSavedBytes = tree->fSavedBytes;
    fTotalBuffers = tree->fTotalBuffers.load();
 
@@ -7404,8 +7452,11 @@ void TTree::Reset(Option_t* option)
    fNotify        = 0;
    fEntries       = 0;
    fNClusterRange = 0;
-   fTotBytes      = 0;
-   fZipBytes      = 0;
+   {
+      std::lock_guard<std::mutex> sentry(fCounterMutex);
+      fTotBytes      = 0;
+      fZipBytes      = 0;
+   }
    fFlushedBytes  = 0;
    fSavedBytes    = 0;
    fTotalBuffers  = 0;
@@ -7434,8 +7485,11 @@ void TTree::ResetAfterMerge(TFileMergeInfo *info)
 {
    fEntries       = 0;
    fNClusterRange = 0;
-   fTotBytes      = 0;
-   fZipBytes      = 0;
+   {
+      std::lock_guard<std::mutex> sentry(fCounterMutex);
+      fTotBytes      = 0;
+      fZipBytes      = 0;
+   }
    fSavedBytes    = 0;
    fFlushedBytes  = 0;
    fTotalBuffers  = 0;
@@ -8823,10 +8877,12 @@ void TTree::Streamer(TBuffer& b)
          } else if (fAutoFlush != 0) {
             // Estimate the cluster size.
             // This will allow TTree::Process to enable the cache.
-            if (fZipBytes != 0) {
-               fCacheSize =  fAutoFlush*(fZipBytes/fEntries);
-            } else if (fTotBytes != 0) {
-               fCacheSize =  fAutoFlush*(fTotBytes/fEntries);
+            Long64_t zipBytes = GetZipBytes();
+            Long64_t totBytes = GetTotBytes();
+            if (zipBytes != 0) {
+               fCacheSize =  fAutoFlush*(zipBytes/fEntries);
+            } else if (totBytes != 0) {
+               fCacheSize =  fAutoFlush*(totBytes/fEntries);
             } else {
                fCacheSize = 30000000;
             }
@@ -8852,8 +8908,11 @@ void TTree::Streamer(TBuffer& b)
       b >> ijunk; fMaxEntryLoop   = (Long64_t)ijunk;
       b >> ijunk; fMaxVirtualSize = (Long64_t)ijunk;
       b >> djunk; fEntries  = (Long64_t)djunk;
-      b >> djunk; fTotBytes = (Long64_t)djunk;
-      b >> djunk; fZipBytes = (Long64_t)djunk;
+      {
+         std::lock_guard<std::mutex> sentry(fCounterMutex);
+         b >> djunk; fTotBytes = (Long64_t)djunk;
+         b >> djunk; fZipBytes = (Long64_t)djunk;
+      }
       b >> ijunk; fAutoSave = (Long64_t)ijunk;
       b >> ijunk; fEstimate = (Long64_t)ijunk;
       if (fEstimate <= 10000) fEstimate = 1000000;
@@ -8861,7 +8920,10 @@ void TTree::Streamer(TBuffer& b)
       if (fBranchRef) fBranchRef->SetTree(this);
       TBranch__SetTree(this,fBranches);
       fLeaves.Streamer(b);
-      fSavedBytes = fTotBytes;
+      {
+         std::lock_guard<std::mutex> sentry(fCounterMutex);
+         fSavedBytes = fTotBytes;
+      }
       if (R__v > 1) fIndexValues.Streamer(b);
       if (R__v > 2) fIndex.Streamer(b);
       if (R__v > 3) {

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4792,6 +4792,8 @@ Int_t TTree::Fit(const char* funcname, const char* varexp, const char* selection
    return -1;
 }
 
+namespace {
+
 struct BoolRAIIToggle {
 
 Bool_t &m_val;
@@ -4801,6 +4803,7 @@ BoolRAIIToggle(Bool_t &val) : m_val(val) { m_val = true; }
 ~BoolRAIIToggle() { m_val = false; }
 };
 
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Write to disk all the basket that have not yet been individually written.


### PR DESCRIPTION
This is based on @dpiparo 's work to parallelize `GetEntry`.  The basic idea is, when we are flushing all active branches, we do each branch in parallel.  We have to maintain mutual exclusion when interacting with the `TTree` or `TFile`, but we can parallelize the compression of the baskets (which is a significant amount of CPU time).

Note the least satisfactory part of this work is having to use a mutex to access the byte-counters in `TTree`; this is because these fields are serialized and `std::atomic<>` is not serializable.  Any hints as to how to get around this?

Setting `MainEvent.cxx` in the `test` sub-directory to use this (with LZMA as the compression algorithm), I get:

```
RealTime=76.340815 seconds, CpuTime=131.770000 seconds
```

@pcanal @Dr15Jones - this spun off from our discussion about CMSSW efficiency.  It's really easy to parallelize `FlushBaskets` using a `tbb::task_group` that I later wait for.  However, continuation-style programming is difficult here because `FlushBaskets` is called from deep callstacks.  Further, there's a lot of state in the basket itself we'd need to unravel.

Looking at stack traces for the sample `Event` program, the next most advantageous place to parallelize compression is here:

```
#11 0x00007f00743e80fe in R__zipMultipleAlgorithm 
#12 0x00007f00729aec25 in TBasket::WriteBuffer 
#13 0x00007f00729b53f3 in TBranch::WriteBasket 
#14 0x00007f00729b5c95 in TBranch::Fill 
#15 0x00007f00729cb630 in TBranchElement::Fill
#16 0x00007f00729cb418 in TBranchElement::Fill 
#17 0x00007f00729cb418 in TBranchElement::Fill 
#18 0x00007f0072a063f3 in TTree::Fill
```

The idea would be to make `WriteBuffer` kick off a separate task, but block `TBranch::Fill` (and a handful of other functions, such as anything that can change the branch's `TFile`) from being called until the `WriteBuffer` task was completed.  Harder than this approach, but not impossible.
