### PR TITLE
TThreadExecutor: Moved tbb headers to the source file.

### DIFF
--- a/core/thread/inc/ROOT/TThreadExecutor.hxx
+++ b/core/thread/inc/ROOT/TThreadExecutor.hxx
@@ -59,16 +59,16 @@ public:
    using TExecutor<TThreadExecutor>::Reduce;
 
 private:
-    void _parallelFor(unsigned start, unsigned end, const std::function<void(unsigned int i)> &f);
-    double _parallelReduceDoubles(const std::vector<double> &objs, const std::function<float(unsigned int a, float b)> &redfunc);
-    float _parallelReduceFloats(const std::vector<float> &objs, const std::function<float(unsigned int a, float b)> &redfunc);
+    void ParallelFor(unsigned start, unsigned end, const std::function<void(unsigned int i)> &f);
+    double ParallelReduceDoubles(const std::vector<double> &objs, const std::function<float(unsigned int a, float b)> &redfunc);
+    float ParallelReduceFloats(const std::vector<float> &objs, const std::function<float(unsigned int a, float b)> &redfunc);
     tbb::task_scheduler_init *fInitTBB;
 };
 
 template<class T>
 class ParallelReductionResolver{
   public:
-  static inline T Reduce(TThreadExecutor *thE, const std::vector<T> &objs, const std::function<T(T a, T b)> &redfunc){
+  static inline T Reduce(TThreadExecutor *threadExecutor, const std::vector<T> &objs, const std::function<T(T a, T b)> &redfunc){
     return std::accumulate(objs.begin(), objs.end(), T{}, redfunc);
   } 
 };
@@ -76,16 +76,16 @@ class ParallelReductionResolver{
 template<>
 class ParallelReductionResolver<double>{
   public:
-  static inline double Reduce(TThreadExecutor *thE, const std::vector<double> &objs, const std::function<double(double a, double b)> &redfunc){
-    return thE->_parallelReduceDoubles(objs, redfunc);
+  static inline double Reduce(TThreadExecutor *threadExecutor, const std::vector<double> &objs, const std::function<double(double a, double b)> &redfunc){
+    return threadExecutor->ParallelReduceDoubles(objs, redfunc);
   }
 };
 
 template<>
 class ParallelReductionResolver<float>{
   public:
-  static inline float Reduce(TThreadExecutor *thE, const std::vector<float> &objs, const std::function<float(float a, float b)> &redfunc){
-    return thE->_parallelReduceFloats(objs, redfunc);
+  static inline float Reduce(TThreadExecutor *threadExecutor, const std::vector<float> &objs, const std::function<float(float a, float b)> &redfunc){
+    return threadExecutor->ParallelReduceFloats(objs, redfunc);
   }
 };
 
@@ -103,7 +103,7 @@ auto TThreadExecutor::Map(F func, unsigned nTimes) -> std::vector<typename std::
    std::vector<retType> reslist(nTimes);
 
    auto lambda = [&](unsigned int i){reslist[i] = func();};
-   _parallelFor(0U, nTimes, lambda);
+   ParallelFor(0U, nTimes, lambda);
 
    return reslist;
 }
@@ -117,7 +117,7 @@ auto TThreadExecutor::Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typen
    std::vector<retType> reslist(end-start);
 
    auto lambda = [&](unsigned int i){reslist[i] = func(i);};
-   _parallelFor(start, end, lambda);
+   ParallelFor(start, end, lambda);
 
    return reslist;
 }
@@ -137,7 +137,7 @@ auto TThreadExecutor::Map(F func, std::vector<T> &args) -> std::vector<typename 
    std::vector<retType> reslist(fNToProcess);
 
    auto lambda = [&](unsigned int i){reslist[i] = func(args[i]);};
-   _parallelFor(0U, fNToProcess, lambda);
+   ParallelFor(0U, fNToProcess, lambda);
 
    return reslist;
 }

--- a/core/thread/src/TThreadExecutor.cxx
+++ b/core/thread/src/TThreadExecutor.cxx
@@ -14,18 +14,18 @@ namespace ROOT{
     fInitTBB->terminate();
   }
 
-  void TThreadExecutor::_parallelFor(unsigned int start, unsigned int end, const std::function<void(unsigned int i)> &f){
+  void TThreadExecutor::ParallelFor(unsigned int start, unsigned int end, const std::function<void(unsigned int i)> &f){
     tbb::parallel_for(start, end, f);
   }
 
- double TThreadExecutor::_parallelReduceDoubles(const std::vector<double> &objs, const std::function<float(unsigned int a, float b)> &redfunc){
+ double TThreadExecutor::ParallelReduceDoubles(const std::vector<double> &objs, const std::function<float(unsigned int a, float b)> &redfunc){
    return tbb::parallel_reduce(tbb::blocked_range<decltype(objs.begin())>(objs.begin(), objs.end()), double{},
                               [redfunc](tbb::blocked_range<decltype(objs.begin())> const & range, double init) {
                               return std::accumulate(range.begin(), range.end(), init, redfunc);
                               }, redfunc);
   }
 
-  float TThreadExecutor::_parallelReduceFloats(const std::vector<float> &objs, const std::function<float(unsigned int a, float b)> &redfunc){
+  float TThreadExecutor::ParallelReduceFloats(const std::vector<float> &objs, const std::function<float(unsigned int a, float b)> &redfunc){
    return tbb::parallel_reduce(tbb::blocked_range<decltype(objs.begin())>(objs.begin(), objs.end()), float{},
                               [redfunc](tbb::blocked_range<decltype(objs.begin())> const & range, float init) {
                               return std::accumulate(range.begin(), range.end(), init, redfunc);

--- a/core/thread/src/TThreadExecutor.cxx
+++ b/core/thread/src/TThreadExecutor.cxx
@@ -18,3 +18,17 @@ namespace ROOT{
     tbb::parallel_for(start, end, f);
   }
 
+ double TThreadExecutor::_parallelReduceDoubles(const std::vector<double> &objs, const std::function<float(unsigned int a, float b)> &redfunc){
+   return tbb::parallel_reduce(tbb::blocked_range<decltype(objs.begin())>(objs.begin(), objs.end()), double{},
+                              [redfunc](tbb::blocked_range<decltype(objs.begin())> const & range, double init) {
+                              return std::accumulate(range.begin(), range.end(), init, redfunc);
+                              }, redfunc);
+  }
+
+  float TThreadExecutor::_parallelReduceFloats(const std::vector<float> &objs, const std::function<float(unsigned int a, float b)> &redfunc){
+   return tbb::parallel_reduce(tbb::blocked_range<decltype(objs.begin())>(objs.begin(), objs.end()), float{},
+                              [redfunc](tbb::blocked_range<decltype(objs.begin())> const & range, float init) {
+                              return std::accumulate(range.begin(), range.end(), init, redfunc);
+                              }, redfunc);
+  }
+}

--- a/core/thread/src/TThreadExecutor.cxx
+++ b/core/thread/src/TThreadExecutor.cxx
@@ -1,0 +1,20 @@
+#include "ROOT/TThreadExecutor.hxx"
+#include "tbb/tbb.h"
+
+namespace ROOT{
+  TThreadExecutor::TThreadExecutor(){
+    fInitTBB = new tbb::task_scheduler_init();
+  }
+
+  TThreadExecutor::TThreadExecutor(size_t nThreads){
+    fInitTBB = new tbb::task_scheduler_init(nThreads);
+  }
+
+  TThreadExecutor::~TThreadExecutor() {
+    fInitTBB->terminate();
+  }
+
+  void TThreadExecutor::_parallelFor(unsigned int start, unsigned int end, const std::function<void(unsigned int i)> &f){
+    tbb::parallel_for(start, end, f);
+  }
+


### PR DESCRIPTION
Fixed one missing header error, limited parallel reduction to floats and doubles  ¯\_(ツ)_/¯

