### PR TITLE
[TMVA/CMake] Fix CMake setup for DNN CUDA implementation

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1264,7 +1264,7 @@ endif()
 #---Check for CUDA and BLAS ---------------------------------------------------------
 if(tmva AND cuda)
   message(STATUS "Looking for CUDA for optional parts of TMVA")
-  find_package(CUDA QUIET)
+  find_package(CUDA 7.5)
   if(NOT CUDA_FOUND)
     if(fail-on-missing)
       message(FATAL_ERROR "CUDA not found. Ensure that the installation of CUDA is in the CMAKE_PREFIX_PATH")

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists.txt file for building ROOT tmva package
 # @author Pere Mato, CERN
 ############################################################################
-#---The following is needed because client codes of TMVA (in ROOT itself) assumes to find header files under /TVMA
+#---The following is needed because client codes of TMVA (in ROOT itself) assumes to find header files under /TMVA
 #execute_process(COMMAND cmake -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/inc ${CMAKE_CURRENT_SOURCE_DIR}/inc/TMVA)
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
@@ -45,6 +45,7 @@ foreach(hs headers1 headers2 headers3 headers4 headers5)
   endforeach()
 endforeach()
 
+#---Assign source files to the implementations -----------------
 SET(DNN_FILES      src/DNN/Architectures/Reference.cxx)
 SET(DNN_CUDA_FILES src/DNN/Architectures/Cuda.cu
                    src/DNN/Architectures/Cuda/CudaBuffers.cxx
@@ -55,10 +56,10 @@ SET(DNN_CPU_FILES  src/DNN/Architectures/Cpu.cxx
 
 #---Handle CUDA dependent code. -----------------
 if(CUDA_FOUND)
-  CUDA_INCLUDE_DIRECTORIES(${ROOT_INCLUDE_DIRS})
   CUDA_ADD_LIBRARY(dnn_cuda ${DNN_CUDA_FILES})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDNNCUDA")
   set(DNN_CUDA_LIBRARIES dnn_cuda ${CUDA_CUBLAS_LIBRARIES})
+  add_dependencies(dnn_cuda move_headers)
 else()
   set(DNN_CUDA_LIBRARIES)
 endif()


### PR DESCRIPTION
- Set minimum CUDA version to 8.0 (doesn't build otherwise)
- Fix include path of CUDA dependent library `dnn_cuda` (previously used path `ROOT_INCLUDE_DIRS` is not in local scope)
