### PR TITLE
Make TTreeReaderValue moveable

### DIFF
--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -45,6 +45,7 @@ namespace Internal {
    class TTreeReaderValueBase {
    public:
       TTreeReaderValueBase(const TTreeReaderValueBase&) = delete;
+      TTreeReaderValueBase(TTreeReaderValueBase&&) = default;
 
       // Status flags, 0 is good
       enum ESetupStatus {


### PR DESCRIPTION
While the `TTreeReaderValue` is indeed not copyable for good reason, I don't see why it shouldn't be moveable (deleting the copy constructor appears to implicitly delete the move constructor).  With this small patch, the following works:

```
  TFile *tf = TFile::Open("somefile.root");
  TTreeReader reader("T", tf);
  auto foo = std::make_tuple( TTreeReaderValue<int>(reader, "branchname") );
```