### PR TITLE
Fix multiple issues in Executors

### DIFF
--- a/core/thread/inc/ROOT/TThreadExecutor.hxx
+++ b/core/thread/inc/ROOT/TThreadExecutor.hxx
@@ -71,6 +71,7 @@ public:
    
   template<class T, class BINARYOP> auto Reduce(const std::vector<T> &objs, BINARYOP redfunc) -> decltype(redfunc(objs.front(), objs.front()));
   template<class T, class R> auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
+  using TExecutor<TThreadExecutor>::Reduce;
 
 protected:
 


### PR DESCRIPTION
- TThreadExecutor's task pool initializer is now a unique_ptr.
- Removed useless Reduction resolver.
- Change the way Reduce was inherited + overloaded. It was working due
  to a GCC bug. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78308
  (thanks, Axel)
- Chunked Map is now protected.