### PR TITLE
[CMake] Remove `QUIET` flag of BLAS `find_package` call

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1276,9 +1276,9 @@ if(tmva AND cuda)
   endif()
 endif()
 
-if(tmva)
+if(tmva AND imt)
   message(STATUS "Looking for BLAS for optional parts of TMVA")
-  find_package(BLAS QUIET)
+  find_package(BLAS)
 endif()
 
 #---Report non implemented options---------------------------------------------------


### PR DESCRIPTION
It's much more convenient this way!