### PR TITLE
Fix issues in Executors

### DIFF
--- a/core/multiproc/inc/ROOT/TProcessExecutor.hxx
+++ b/core/multiproc/inc/ROOT/TProcessExecutor.hxx
@@ -72,8 +72,7 @@ public:
    void SetNWorkers(unsigned n) { TMPClient::SetNWorkers(n); }
    unsigned GetNWorkers() const { return TMPClient::GetNWorkers(); }
 
-   template<class T, class BINARYOP> auto Reduce(const std::vector<T> &objs, BINARYOP redfunc)-> decltype(redfunc(objs.front(), objs.front())) = delete;
-   using TExecutor<TProcessExecutor>::Reduce;
+   template<class T, class R> T Reduce(const std::vector<T> &objs, R redfunc);
 
 private:
    template<class T> void Collect(std::vector<T> &reslist);
@@ -201,6 +200,13 @@ auto TProcessExecutor::Map(F func, ROOT::TSeq<INTEGER> args) -> std::vector<type
 // tell doxygen to stop ignoring code
 /// \endcond
 
+template<class T, class R>
+T TProcessExecutor::Reduce(const std::vector<T> &objs, R redfunc)
+{
+   // check we can apply reduce to objs
+   static_assert(std::is_same<decltype(redfunc(objs)), T>::value, "redfunc does not have the correct signature");
+   return redfunc(objs);
+}
 
 template<class F>
 auto TProcessExecutor::ProcTree(const std::vector<std::string>& fileNames, F procFunc, const std::string& treeName, ULong64_t nToProcess) -> typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type

--- a/core/thread/src/TThreadExecutor.cxx
+++ b/core/thread/src/TThreadExecutor.cxx
@@ -2,12 +2,10 @@
 #include "tbb/tbb.h"
 
 namespace ROOT{
-  TThreadExecutor::TThreadExecutor(){
-    fInitTBB = new tbb::task_scheduler_init();
+  TThreadExecutor::TThreadExecutor():fInitTBB(new tbb::task_scheduler_init()){
   }
 
-  TThreadExecutor::TThreadExecutor(size_t nThreads){
-    fInitTBB = new tbb::task_scheduler_init(nThreads);
+  TThreadExecutor::TThreadExecutor(size_t nThreads):fInitTBB(new tbb::task_scheduler_init(nThreads)){
   }
 
   TThreadExecutor::~TThreadExecutor() {
@@ -18,14 +16,14 @@ namespace ROOT{
     tbb::parallel_for(start, end, f);
   }
 
- double TThreadExecutor::ParallelReduceDoubles(const std::vector<double> &objs, const std::function<float(unsigned int a, float b)> &redfunc){
+  double TThreadExecutor::ParallelReduce(const std::vector<double> &objs, const std::function<double(double a, double b)> &redfunc){
    return tbb::parallel_reduce(tbb::blocked_range<decltype(objs.begin())>(objs.begin(), objs.end()), double{},
                               [redfunc](tbb::blocked_range<decltype(objs.begin())> const & range, double init) {
                               return std::accumulate(range.begin(), range.end(), init, redfunc);
                               }, redfunc);
   }
 
-  float TThreadExecutor::ParallelReduceFloats(const std::vector<float> &objs, const std::function<float(unsigned int a, float b)> &redfunc){
+  float TThreadExecutor::ParallelReduce(const std::vector<float> &objs, const std::function<float(float a, float b)> &redfunc){
    return tbb::parallel_reduce(tbb::blocked_range<decltype(objs.begin())>(objs.begin(), objs.end()), float{},
                               [redfunc](tbb::blocked_range<decltype(objs.begin())> const & range, float init) {
                               return std::accumulate(range.begin(), range.end(), init, redfunc);


### PR DESCRIPTION
- TThreadExecutor's task pool initializer was being leaked. Now is an unique_ptr.
- Removed useless Reduction resolver.
- Base class (TExecutor) functions with the same name and parameter list
than existing ones should not be introduced by the using-declaration
in derived classes (TThreadExecutor/TProcessExecutor).

See the bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78308