### PR TITLE
Change "TTreeReader::Reset" to "Restart" in error message

### DIFF
--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -419,7 +419,7 @@ Bool_t TTreeReader::RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* re
 {
    if (fProxiesSet) {
       Error("RegisterValueReader",
-            "Error registering reader for %s: TTreeReaderValue/Array objects must be created before the call to Next() / SetEntry() / SetLocalEntry(), or after TTreeReader::Reset()!",
+            "Error registering reader for %s: TTreeReaderValue/Array objects must be created before the call to Next() / SetEntry() / SetLocalEntry(), or after TTreeReader::Restart()!",
             reader->GetBranchName());
       return false;
    }


### PR DESCRIPTION
As per Jira ticket ROOT-8483:

Creating a TTreeReaderValue after having looped over a TTreeReader prompts an error message at runtime. This error mentions calling `TTreeReader::Reset` as a solution, but said method does not exist.
Assuming `TTreeReader::Restart` was meant, the patch is trivial.