### PR TITLE
[TMVA] Fix multiclass classification with two classes in method DNN

### DIFF
--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -141,6 +141,7 @@ void TMVA::MethodDNN::DeclareOptions()
                     " or cross entropy (binary classifcation).");
    AddPreDefVal(TString("CROSSENTROPY"));
    AddPreDefVal(TString("SUMOFSQUARES"));
+   AddPreDefVal(TString("MUTUALEXCLUSIVE"));
 
    DeclareOptionRef(fWeightInitializationString="XAVIER",
                     "WeightInitialization",

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -402,9 +402,9 @@ void TMVA::MethodDNN::ProcessOptions()
    fLayout = TMVA::MethodDNN::ParseLayoutString (fLayoutString);
    size_t inputSize = GetNVariables ();
    size_t outputSize = 1;
-   if (GetNTargets() != 0) {
+   if (fAnalysisType == Types::kRegression && GetNTargets() != 0) {
       outputSize = GetNTargets();
-   } else if (DataInfo().GetNClasses() > 2) {
+   } else if (fAnalysisType == Types::kMulticlass && DataInfo().GetNClasses() >= 2) {
       outputSize = DataInfo().GetNClasses();
    }
 


### PR DESCRIPTION
It's a corner-case, but still it took me some time to figure this out. The behaviour before was returning a probability of 1 for all events (because the softmax has only one output, which gets the full probability of 1).