### PR TITLE
[TMVA] Introduce private local python namespace in PyMVA

### DIFF
--- a/tmva/pymva/inc/TMVA/PyMethodBase.h
+++ b/tmva/pymva/inc/TMVA/PyMethodBase.h
@@ -89,7 +89,7 @@ namespace TMVA {
       static void PySetProgramName(TString name);
       static TString Py_GetProgramName();
 
-      static PyObject *Eval(TString code); // required to parse booking options from string to pyobjects
+      PyObject *Eval(TString code); // required to parse booking options from string to pyobjects
       static void Serialize(TString file,PyObject *classifier);
       static void UnSerialize(TString file,PyObject** obj);
 
@@ -139,9 +139,9 @@ namespace TMVA {
       static PyObject *fPickleDumps; // Function to dumps PyObject information into string
       static PyObject *fPickleLoads; // Function to load PyObject information from string
 
-      static PyObject *fMain; // module __main__ to get namesapace local and global
+      static PyObject *fMain; // module __main__ to get namespace local and global
       static PyObject *fGlobalNS; // global namesapace
-      static PyObject *fLocalNS; // local namesapace
+      PyObject *fLocalNS; // local namesapace
 
       ClassDef(PyMethodBase, 0) // Virtual base class for all TMVA method
 

--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -14,9 +14,6 @@
 #include <Python.h>    // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE
 #include <TMVA/PyMethodBase.h>
 
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #include "TMVA/DataSet.h"
 #include "TMVA/DataSetInfo.h"
 #include "TMVA/MsgLogger.h"
@@ -35,6 +32,8 @@ using namespace TMVA;
 
 ClassImp(PyMethodBase)
 
+// NOTE: Introduce here nothing that breaks if multiple instances
+// of the same method share these objects, e.g., the local namespace.
 PyObject *PyMethodBase::fModuleBuiltin = NULL;
 PyObject *PyMethodBase::fEval = NULL;
 PyObject *PyMethodBase::fOpen = NULL;
@@ -45,7 +44,6 @@ PyObject *PyMethodBase::fPickleLoads = NULL;
 
 PyObject *PyMethodBase::fMain = NULL;
 PyObject *PyMethodBase::fGlobalNS = NULL;
-PyObject *PyMethodBase::fLocalNS = NULL;
 
 class PyGILRAII {
    PyGILState_STATE m_GILState;
@@ -65,6 +63,13 @@ PyMethodBase::PyMethodBase(const TString &jobName,
    if (!PyIsInitialized()) {
       PyInitialize();
    }
+
+   // Set up private local namespace for each method instance
+   fLocalNS = PyDict_New();
+   if (!fLocalNS) {
+      TMVA::MsgLogger Log;
+      Log << kFATAL << "Can't init local namespace" << Endl;
+   }
 }
 
 //_______________________________________________________________________
@@ -75,6 +80,13 @@ PyMethodBase::PyMethodBase(Types::EMVA methodType,
 {
    if (!PyIsInitialized()) {
       PyInitialize();
+   }
+
+   // Set up private local namespace for each method instance
+   fLocalNS = PyDict_New();
+   if (!fLocalNS) {
+      TMVA::MsgLogger Log;
+      Log << kFATAL << "Can't init local namespace" << Endl;
    }
 }
 
@@ -94,6 +106,10 @@ PyObject *PyMethodBase::Eval(TString code)
 }
 
 //_______________________________________________________________________
+// NOTE: We introduce a shared global namespace fGlobalNS, but using
+// a private local namespace fLocalNS. This prohibits the interference
+// of instances of the same method with the same factory, e.g., by overriding
+// variables in the same local namespace.
 void PyMethodBase::PyInitialize()
 {
    TMVA::MsgLogger Log;
@@ -118,12 +134,6 @@ void PyMethodBase::PyInitialize()
    fGlobalNS = PyModule_GetDict(fMain);
    if (!fGlobalNS) {
       Log << kFATAL << "Can't init global namespace" << Endl;
-      Log << Endl;
-   }
-
-   fLocalNS = PyDict_New();
-   if (!fMain) {
-      Log << kFATAL << "Can't init local namespace" << Endl;
       Log << Endl;
    }
 
@@ -167,8 +177,6 @@ void PyMethodBase::PyInitialize()
 
    Py_DECREF(pName);
    Py_DECREF(pDict);
-
-
 }
 
 //_______________________________________________________________________


### PR DESCRIPTION
The current implementation of the PyMVA interface in `PyMethodBase` has following problem:

We are using currently a global local python namespace for **all** instances of **all** PyMVA method. So you can easily interfere with an other method running in the same factory. Most likely, this happens if you book two instances of the same method in one factory.

We can solve this by introducing **private** local python namespaces. In this version, we are sharing the global namespaces with all instances of a PyMVA method (and ofc the running python instance), but create a seperate local namespace for each instance. So you can do whatever you want in your method/instance and you don't interfere with others.