### PR TITLE
Undefine HZ macro to avoid name clash with variable name

### DIFF
--- a/tutorials/graphs/zdemo.C
+++ b/tutorials/graphs/zdemo.C
@@ -25,6 +25,10 @@
 #include "TGraph.h"
 #include "TFrame.h"
 
+#ifdef HZ
+#undef HZ
+#endif
+
 const Int_t NMAX = 20;
 Int_t NLOOP;
 Float_t Z[NMAX], HZ[NMAX], PT[NMAX], INVSIG[NMAX];


### PR DESCRIPTION
On some platforms there is a HZ macro defined that makes the test fail. This pull request undefines the HZ macro if it is defined allowing the test to succeed.