### PR TITLE
Use full paths to images

### DIFF
--- a/tutorials/image/rose_image.C
+++ b/tutorials/image/rose_image.C
@@ -20,7 +20,9 @@ TCanvas *c1;
 
 void rose_image()
 {
-   TImage *img = TImage::Open("$ROOTSYS/tutorials/image/rose512.jpg");
+   TString dir = TROOT::GetTutorialDir();
+
+   TImage *img = TImage::Open(dir + "/image/rose512.jpg");
 
    if (!img) {
       printf("Could not create an image... exit\n");
@@ -41,9 +43,9 @@ void rose_image()
 
    // draw text over image with foreground specified by pixmap
    img->DrawText(250, 350, "goodbye cruel world ...", 24, 0,
-                 ar, TImage::kPlain, "fore.xpm");
+                 ar, TImage::kPlain, dir + "/image/fore.xpm");
 
-   TImage *img2 = TImage::Open("mditestbg.xpm");
+   TImage *img2 = TImage::Open(dir + "/image/mditestbg.xpm");
 
    // tile image
    img2->Tile(img->GetWidth(), img->GetHeight());


### PR DESCRIPTION
This tutorial does not use full paths to the images fore.xpm and mditestbg.xpm. These images are therefore not found during execution.

The image on the documentation page therefore does not look as expected:
https://root.cern/doc/master/rose__image_8C.html

E.g. the text in the lower right corner of the images is barely readable due to this problem.

This pull request addresses this issue.

Note: I have used TROOT::GetTutorialDir() instead of TROOT::GetTutorialsDir() since I apply this change after appling the changes in pull request #130. If you decide to fix this issue first you need to put the s back in.