### PR TITLE
No such thing as ROOT_unfold_FOUND

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -69,13 +69,10 @@ if(NOT ROOT_unuran_FOUND)
                    math/multidimSampling.C)
 endif()
 
-if(NOT ROOT_unfold_FOUND)
-  set(unfold_veto unfold/*.C)
-endif()
-
 if(NOT ROOT_xml_FOUND)
   set(xml_veto  xml/*.C
-                histfactory/*.C)   # histfactory requires xml
+                histfactory/*.C    # histfactory requires xml
+                unfold/*.C)        # unfold requires xml
 endif()
 
 # variables identifying the package must have the package name  in lower case (it corresponds to the CMake option name)
@@ -189,7 +186,6 @@ set(all_veto hsimple.C
              ${xml_veto}
              ${fitsio_veto}
              ${tmva_veto}
-             ${unfold_veto}
              ${mathmore_veto}
              ${fftw3_veto}
              ${opengl_veto}


### PR DESCRIPTION
There is no such thing as ROOT_unfold_FOUND. It is built conditionally depending on whether there is xml support or not. From hist/CMakeLists.txt:
~~~
if(xml)
  add_subdirectory(unfold)
endif()
~~~
The veto for the tutorials should therefore also depend on the xml support.
