### PR TITLE
[ROOT-8468] Fix multithreading unzipping

### DIFF
--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -447,7 +447,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
    if (pf) {
       Int_t res = -1;
       Bool_t free = kTRUE;
-      char *buffer;
+      char *buffer = nullptr;
       res = pf->GetUnzipBuffer(&buffer, pos, len, &free);
       if (R__unlikely(res >= 0)) {
          len = ReadBasketBuffersUnzip(buffer, res, free, file);

--- a/tree/tree/src/TTreeCacheUnzip.cxx
+++ b/tree/tree/src/TTreeCacheUnzip.cxx
@@ -1238,7 +1238,6 @@ Int_t TTreeCacheUnzip::UnzipCache(Int_t &startindex, Int_t &locbuffsz, char *&lo
 
    fUnzipDoneCondition->Signal();
 
-   delete [] ptr;
    return 0;
 }
 


### PR DESCRIPTION
@pcanal @bbockelm 

This pull request fix the bug here https://sft.its.cern.ch/jira/browse/ROOT-8468.

The fist error is due to the dangling pointer. "buffer" never gets to be allocated in the function GetUnzipBuffer.

The second error is deallocating the memory "ptr" point to. Therefore, fUnzipChunks[idxtounzip] becomes null pointer.

It should work now. To test the parallel unzipping, simply random generate events and read them.

/PATH/TO/TEST/eventexe 1000 6 99 1 1000 (generate 1000 events with zlib)
/PATH/TO/TEST/eventexe 1000 6 99 20 1000 (unzip and read 1000 events in sequential manner)
/PATH/TO/TEST/eventexe 1000 6 99 21 1000 (unzip and read 1000 events in parallel)