### PR TITLE
Improve parallelism in TTree::Fill

### DIFF
--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -64,26 +64,30 @@ class TTreeCloner;
 ///
 class TBranchIMTHelper {
 public:
-    template<typename FN> void run(const FN &lambda) {
+   template<typename FN> void run(const FN &lambda) {
 #ifdef R__USE_IMT
-        if (!fGroup) {fGroup.reset(new tbb::task_group());}
-        fGroup->run([=](){auto nbytes = lambda(); if (nbytes >= 0) {fBytes += nbytes;} else {++fNerrors;} });
+      if (!fGroup) {fGroup.reset(new tbb::task_group());}
+      fGroup->run([=](){auto nbytes = lambda(); if (nbytes >= 0) {fBytes += nbytes;} else {++fNerrors;} });
+#else
+      (void)lambda;
 #endif
-    }
+   }
 
-    void wait() {
+   void Wait() {
 #ifdef R__USE_IMT
-        if (fGroup) {fGroup->wait();}
+      if (fGroup) fGroup->wait();
 #endif
-    }
+   }
 
-    Long64_t GetNbytes() {return fBytes;}
-    Long64_t GetNerrors() {return fNerrors;}
+   Long64_t GetNbytes() {return fBytes;}
+   Long64_t GetNerrors() {return fNerrors;}
 
 private:
-    std::atomic<Long64_t> fBytes{0};   // Total number of bytes written by this helper.
-    std::atomic<Int_t>    fNerrors{0}; // Total error count of all tasks done by this helper.
-    std::unique_ptr<tbb::task_group> fGroup;
+   std::atomic<Long64_t> fBytes{0};   // Total number of bytes written by this helper.
+   std::atomic<Int_t>    fNerrors{0}; // Total error count of all tasks done by this helper.
+#ifdef R__USE_IMT
+   std::unique_ptr<tbb::task_group> fGroup;
+#endif
 };
 
 class TBranch : public TNamed , public TAttFill {

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -23,6 +23,7 @@
 //     the list of TLeaves (branch description)                         //
 //////////////////////////////////////////////////////////////////////////
 
+#include <memory>
 
 #ifndef ROOT_TNamed
 #include "TNamed.h"
@@ -40,6 +41,10 @@
 #include "TDataType.h"
 #endif
 
+#ifdef R__USE_IMT
+#include <tbb/task_group.h>
+#endif
+
 class TTree;
 class TBasket;
 class TLeaf;
@@ -55,10 +60,38 @@ class TTreeCloner;
    const Int_t kBranchAny    = BIT(17); // branch is an object*
    const Int_t kMapObject    = kBranchObject | kBranchAny;
 
+/// A helper class for managing IMT work during TTree:Fill operations.
+///
+class TBranchIMTHelper {
+public:
+    template<typename FN> void run(const FN &lambda) {
+#ifdef R__USE_IMT
+        if (!fGroup) {fGroup.reset(new tbb::task_group());}
+        fGroup->run([=](){auto nbytes = lambda(); if (nbytes >= 0) {fBytes += nbytes;} else {++fNerrors;} });
+#endif
+    }
+
+    void wait() {
+#ifdef R__USE_IMT
+        if (fGroup) {fGroup->wait();}
+#endif
+    }
+
+    Long64_t GetNbytes() {return fBytes;}
+    Long64_t GetNerrors() {return fNerrors;}
+
+private:
+    std::atomic<Long64_t> fBytes{0};   // Total number of bytes written by this helper.
+    std::atomic<Int_t>    fNerrors{0}; // Total error count of all tasks done by this helper.
+    std::unique_ptr<tbb::task_group> fGroup;
+};
+
 class TBranch : public TNamed , public TAttFill {
 
 protected:
    friend class TTreeCloner;
+   friend class TTree;
+
    // TBranch status bits
    enum EStatusBits {
       kAutoDelete = BIT(15),
@@ -117,12 +150,13 @@ protected:
    void     Init(const char *name, const char *leaflist, Int_t compress);
 
    TBasket *GetFreshBasket();
-   Int_t    WriteBasket(TBasket* basket, Int_t where);
+   Int_t    WriteBasket(TBasket* basket, Int_t where) {return WriteBasketImpl(basket, where, nullptr);}
 
    TString  GetRealFileName() const;
 
 private:
    Int_t FillEntryBuffer(TBasket* basket,TBuffer* buf, Int_t& lnew);
+   Int_t    WriteBasketImpl(TBasket* basket, Int_t where, TBranchIMTHelper *);
    TBranch(const TBranch&);             // not implemented
    TBranch& operator=(const TBranch&);  // not implemented
 
@@ -138,7 +172,8 @@ public:
    virtual void      DeleteBaskets(Option_t* option="");
    virtual void      DropBaskets(Option_t *option = "");
            void      ExpandBasketArrays();
-   virtual Int_t     Fill();
+           Int_t     Fill() {return FillImpl(nullptr);}
+   virtual Int_t     FillImpl(TBranchIMTHelper *);
    virtual TBranch  *FindBranch(const char *name);
    virtual TLeaf    *FindLeaf(const char *name);
            Int_t     FlushBaskets();

--- a/tree/tree/inc/TBranchClones.h
+++ b/tree/tree/inc/TBranchClones.h
@@ -49,7 +49,6 @@ public:
    virtual ~TBranchClones();
 
    virtual void    Browse(TBrowser *b);
-   virtual Int_t   Fill();
    virtual const char* GetClassName() const { return fClassName; }
    virtual Int_t   GetEntry(Long64_t entry=0, Int_t getall = 0);
    virtual Int_t   GetN() const {return fN;}
@@ -62,6 +61,9 @@ public:
    virtual void    SetBasketSize(Int_t buffsize);
    virtual void    SetTree(TTree *tree) { fTree = tree; fBranchCount->SetTree(tree); }
    virtual void    UpdateFile();
+   virtual Int_t   FillImpl(TBranchIMTHelper *);
+
+private:
 
    ClassDef(TBranchClones,2);  //Branch in case of an array of clone objects
 };

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -182,7 +182,6 @@ public:
    virtual                  ~TBranchElement();
 
    virtual void             Browse(TBrowser* b);
-   virtual Int_t            Fill();
    virtual TBranch         *FindBranch(const char *name);
    virtual TLeaf           *FindLeaf(const char *name);
    virtual char            *GetAddress() const;
@@ -250,6 +249,9 @@ public:
       kClonesMemberNode = 31,
       kSTLMemberNode = 41
    };
+
+private:
+   virtual Int_t            FillImpl(TBranchIMTHelper *);
 
    ClassDef(TBranchElement,10)  // Branch in case of an object
 };

--- a/tree/tree/inc/TBranchObject.h
+++ b/tree/tree/inc/TBranchObject.h
@@ -42,7 +42,6 @@ public:
    virtual ~TBranchObject();
 
    virtual void        Browse(TBrowser *b);
-   virtual Int_t       Fill();
    virtual const char* GetClassName() const { return fClassName.Data(); };
    virtual const char* GetObjClassName() { return fClassName.Data(); };
    virtual Int_t       GetEntry(Long64_t entry=0, Int_t getall = 0);
@@ -56,6 +55,9 @@ public:
    virtual void        SetBasketSize(Int_t buffsize);
    virtual void        SetupAddresses();
    virtual void        UpdateAddress();
+
+private:
+   virtual Int_t       FillImpl(TBranchIMTHelper *);
 
    ClassDef(TBranchObject,1);  //Branch in case of an object
 };

--- a/tree/tree/inc/TBranchRef.h
+++ b/tree/tree/inc/TBranchRef.h
@@ -45,7 +45,6 @@ public:
    TBranchRef(TTree *tree);
    virtual ~TBranchRef();
    virtual void    Clear(Option_t *option="");
-   virtual Int_t   Fill();
    TRefTable      *GetRefTable() const {return fRefTable;}
    virtual Bool_t  Notify();
    virtual void    Print(Option_t *option="") const;
@@ -53,6 +52,9 @@ public:
    virtual void    ResetAfterMerge(TFileMergeInfo *);
    virtual Int_t   SetParent(const TObject* obj, Int_t branchID);
    virtual void    SetRequestedEntry(Long64_t entry) {fRequestedEntry = entry;}
+
+private:
+   virtual Int_t   FillImpl(TBranchIMTHelper *);
 
    ClassDef(TBranchRef,1);  //to support referenced objects on other branches
 };

--- a/tree/tree/inc/TBranchSTL.h
+++ b/tree/tree/inc/TBranchSTL.h
@@ -32,7 +32,6 @@ class TBranchSTL: public TBranch {
       virtual ~TBranchSTL();
       virtual void           Browse( TBrowser *b );
       virtual Bool_t         IsFolder() const;
-      virtual Int_t          Fill();
       virtual const char    *GetClassName() const { return fClassName.Data(); }
       virtual Int_t          GetExpectedType(TClass *&clptr,EDataType &type);
       virtual Int_t          GetEntry( Long64_t entry = 0, Int_t getall = 0 );
@@ -46,6 +45,7 @@ class TBranchSTL: public TBranch {
 
    void ReadLeavesImpl( TBuffer& b );
    void FillLeavesImpl( TBuffer& b );
+   virtual Int_t          FillImpl(TBranchIMTHelper *);
 
 #ifndef __CINT__
       struct ElementBranchHelper_t

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -807,7 +807,7 @@ Int_t TBranch::FillImpl(TBranchIMTHelper *imt_helper)
          return nbytes;
       }
       Int_t nout = WriteBasketImpl(basket,fWriteBasket, imt_helper);
-      if (nout < 0) {Error("TBranch::Fill", "Failed to write out basket.\n");}
+      if (nout < 0) Error("TBranch::Fill", "Failed to write out basket.\n");
       return (nout >= 0) ? nbytes : -1;
    }
    return nbytes;
@@ -2596,9 +2596,12 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, TBranchIMTHelper *i
       fEntryOffsetLen = 2*nevbuf; // assume some fluctuations.
    }
 
+   // Note: captures `basket`, `where`, and `this` by value; modifies the TBranch and basket,
+   // as we make a copy of the pointer.  We cannot capture `basket` by reference as the pointer
+   // itself might be modified after `WriteBasketImpl` exits.
    auto do_updates = [=]() {
       Int_t nout  = basket->WriteBuffer();    //  Write buffer
-      if (nout < 0) {Error("TBranch::WriteBasketImpl", "basket's WriteBuffer failed.\n");}
+      if (nout < 0) Error("TBranch::WriteBasketImpl", "basket's WriteBuffer failed.\n");
       fBasketBytes[where]  = basket->GetNbytes();
       fBasketSeek[where]   = basket->GetSeekKey();
       Int_t addbytes = basket->GetObjlen() + basket->GetKeylen();

--- a/tree/tree/src/TBranchClones.cxx
+++ b/tree/tree/src/TBranchClones.cxx
@@ -221,7 +221,7 @@ void TBranchClones::Browse(TBrowser* b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Loop on all branches and fill Basket buffer.
 
-Int_t TBranchClones::Fill()
+Int_t TBranchClones::FillImpl(TBranchIMTHelper *imt_helper)
 {
    Int_t i = 0;
    Int_t nbytes = 0;
@@ -246,13 +246,13 @@ Int_t TBranchClones::Fill()
          leaf->SetAddress();
       }
    }
-   nbytes += fBranchCount->Fill();
+   nbytes += fBranchCount->FillImpl(imt_helper);
    for (i = 0; i < nbranches; i++)  {
       TBranch* branch = (TBranch*) fBranches.UncheckedAt(i);
       TObjArray* leaves = branch->GetListOfLeaves();
       TLeaf* leaf = (TLeaf*) leaves->UncheckedAt(0);
       leaf->Import(fList, fN);
-      nbytes += branch->Fill();
+      nbytes += branch->FillImpl(imt_helper);
    }
    return nbytes;
 }

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -1182,7 +1182,7 @@ void TBranchElement::BuildTitle(const char* name)
 ///
 /// Note: We not not use any member functions from TLeafElement!
 
-Int_t TBranchElement::Fill()
+Int_t TBranchElement::FillImpl(TBranchIMTHelper *imt_helper)
 {
    Int_t nbytes = 0;
    Int_t nwrite = 0;
@@ -1218,7 +1218,7 @@ Int_t TBranchElement::Fill()
    if (!nbranches) {
       // No sub-branches.
       if (!TestBit(kDoNotProcess)) {
-         nwrite = TBranch::Fill();
+         nwrite = TBranch::FillImpl(imt_helper);
          if (nwrite < 0) {
             Error("Fill", "Failed filling branch:%s, nbytes=%d", GetName(), nwrite);
             ++nerror;
@@ -1230,7 +1230,7 @@ Int_t TBranchElement::Fill()
       // We have sub-branches.
       if (fType == 3 || fType == 4) {
          // TClonesArray or STL container counter
-         nwrite = TBranch::Fill();
+         nwrite = TBranch::FillImpl(imt_helper);
          if (nwrite < 0) {
             Error("Fill", "Failed filling branch:%s, nbytes=%d", GetName(), nwrite);
             ++nerror;
@@ -1243,7 +1243,7 @@ Int_t TBranchElement::Fill()
       for (Int_t i = 0; i < nbranches; ++i) {
          TBranchElement* branch = (TBranchElement*) fBranches[i];
          if (!branch->TestBit(kDoNotProcess)) {
-            nwrite = branch->Fill();
+            nwrite = branch->FillImpl(imt_helper);
             if (nwrite < 0) {
                Error("Fill", "Failed filling branch:%s.%s, nbytes=%d", GetName(), branch->GetName(), nwrite);
                nerror++;

--- a/tree/tree/src/TBranchObject.cxx
+++ b/tree/tree/src/TBranchObject.cxx
@@ -169,7 +169,7 @@ void TBranchObject::Browse(TBrowser* b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Loop on all leaves of this branch to fill Basket buffer.
 
-Int_t TBranchObject::Fill()
+Int_t TBranchObject::FillImpl(TBranchIMTHelper *imt_helper)
 {
    Int_t nbytes = 0;
    Int_t nbranches = fBranches.GetEntriesFast();
@@ -179,13 +179,13 @@ Int_t TBranchObject::Fill()
       for (Int_t i = 0; i < nbranches; ++i)  {
          TBranch* branch = (TBranch*) fBranches[i];
          if (!branch->TestBit(kDoNotProcess)) {
-            Int_t bc = branch->Fill();
+            Int_t bc = branch->FillImpl(imt_helper);
             nbytes += bc;
          }
       }
    } else {
       if (!TestBit(kDoNotProcess)) {
-         Int_t bc = TBranch::Fill();
+         Int_t bc = TBranch::FillImpl(imt_helper);
          nbytes += bc;
       }
    }

--- a/tree/tree/src/TBranchRef.cxx
+++ b/tree/tree/src/TBranchRef.cxx
@@ -100,9 +100,9 @@ void TBranchRef::Clear(Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill the branch basket with the referenced objects parent numbers.
 
-Int_t TBranchRef::Fill()
+Int_t TBranchRef::FillImpl(TBranchIMTHelper *imt_helper)
 {
-   Int_t nbytes = TBranch::Fill();
+   Int_t nbytes = TBranch::FillImpl(imt_helper);
    return nbytes;
 }
 

--- a/tree/tree/src/TBranchSTL.cxx
+++ b/tree/tree/src/TBranchSTL.cxx
@@ -162,7 +162,7 @@ void TBranchSTL::Browse( TBrowser *b )
 ////////////////////////////////////////////////////////////////////////////////
 /// Cleanup after revious fill.
 
-Int_t TBranchSTL::Fill()
+Int_t TBranchSTL::FillImpl(TBranchIMTHelper *imt_helper)
 {
    BranchMap_t::iterator brIter;
    for( brIter = fBranchMap.begin(); brIter != fBranchMap.end(); ++brIter )
@@ -185,7 +185,7 @@ Int_t TBranchSTL::Fill()
          ///////////////////////////////////////////////////////////////////////
 
          fInd.SetNumItems( 0 );
-         bytes = TBranch::Fill();
+         bytes = TBranch::FillImpl(imt_helper);
 
          if( bytes < 0 ) {
             Error( "Fill", "The IO error while writing the indices!");
@@ -199,7 +199,7 @@ Int_t TBranchSTL::Fill()
 
          for( Int_t i = 0; i < fBranches.GetEntriesFast(); ++i ) {
             TBranch *br = (TBranch *)fBranches.UncheckedAt(i);
-            bytes = br->Fill();
+            bytes = br->FillImpl(imt_helper);
             if( bytes < 0 ) {
                Error( "Fill", "The IO error while writing the branch %s!", br->GetName() );
                return -1;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4423,7 +4423,7 @@ Int_t TTree::Fill()
    }
    #ifdef R__USE_IMT
    if (imt_helper) {
-      imt_helper->wait();
+      imt_helper->Wait();
       fIMTFlush = false;
       const_cast<TTree*>(this)->AddTotBytes(fIMTTotBytes);
       const_cast<TTree*>(this)->AddZipBytes(fIMTZipBytes);

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -4384,13 +4384,24 @@ Int_t TTree::Fill()
    if (fBranchRef) {
       fBranchRef->Clear();
    }
+
+   std::unique_ptr<TBranchIMTHelper> imt_helper;
+   #ifdef R__USE_IMT
+   if (fIMTEnabled) {
+      fIMTFlush = true;
+      fIMTZipBytes.store(0);
+      fIMTTotBytes.store(0);
+      imt_helper.reset(new TBranchIMTHelper());
+   }
+   #endif
+
    for (Int_t i = 0; i < nb; ++i) {
       // Loop over all branches, filling and accumulating bytes written and error counts.
       TBranch* branch = (TBranch*) fBranches.UncheckedAt(i);
       if (branch->TestBit(kDoNotProcess)) {
          continue;
       }
-      Int_t nwrite = branch->Fill();
+      Int_t nwrite = branch->FillImpl(imt_helper.get());
       if (nwrite < 0)  {
          if (nerror < 2) {
             Error("Fill", "Failed filling branch:%s.%s, nbytes=%d, entry=%lld\n"
@@ -4410,6 +4421,17 @@ Int_t TTree::Fill()
          nbytes += nwrite;
       }
    }
+   #ifdef R__USE_IMT
+   if (imt_helper) {
+      imt_helper->wait();
+      fIMTFlush = false;
+      const_cast<TTree*>(this)->AddTotBytes(fIMTTotBytes);
+      const_cast<TTree*>(this)->AddZipBytes(fIMTZipBytes);
+      nbytes += imt_helper->GetNbytes();
+      nerror += imt_helper->GetNerrors();
+   }
+   #endif
+
    if (fBranchRef) {
       fBranchRef->Fill();
    }
@@ -4839,7 +4861,7 @@ Int_t TTree::FlushBaskets() const
    Int_t nb = lb->GetEntriesFast();
 
 #ifdef R__USE_IMT
-   if (ROOT::IsImplicitMTEnabled() && fIMTEnabled) {
+   if (fIMTEnabled) {
       if (fSortedBranches.empty()) { const_cast<TTree*>(this)->InitializeSortedBranches(); }
 
       BoolRAIIToggle sentry(fIMTFlush);
@@ -5317,7 +5339,7 @@ Int_t TTree::GetEntry(Long64_t entry, Int_t getall)
    };
 
 #ifdef R__USE_IMT
-   if (ROOT::IsImplicitMTEnabled() && fIMTEnabled) {
+   if (fIMTEnabled) {
       if (fSortedBranches.empty()) InitializeSortedBranches();
 
       // Enable this IMT use case (activate its locks)


### PR DESCRIPTION
Now, we create TBB tasks for compression whenever `TTree::Fill` is called and a basket must be compressed.  In CMS, we saw significant speedup on KNL and high-core-count Xeons by doing this over the existing basic write IMT (likely because we have some branches that are flushed to disk much more frequently than targeted by the auto-flush routines).