### PR TITLE
[RooFit] Add missing 'add' functions to RooArgSet.

### DIFF
--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -83,9 +83,19 @@ public:
   virtual TObject* create(const char* newname) const { return new RooArgSet(newname); }
   RooArgSet& operator=(const RooArgSet& other) { RooAbsCollection::operator=(other) ; return *this ;}
 
-  using RooAbsCollection::add;
-  using RooAbsCollection::addOwned;
-  using RooAbsCollection::addClone;
+  virtual Bool_t add(const RooAbsCollection& col, Bool_t silent=kFALSE) {
+    // Add all elements in list to collection
+    return RooAbsCollection::add(col, silent);
+  }
+  virtual Bool_t addOwned(const RooAbsCollection& col, Bool_t silent=kFALSE) {
+    // Add all elements in list as owned components to collection
+    return RooAbsCollection::addOwned(col, silent);
+  }
+  virtual void addClone(const RooAbsCollection& col, Bool_t silent=kFALSE) {
+    // Add owned clone of all elements of list to collection
+    RooAbsCollection::addClone(col, silent);
+  }
+
   virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) ;
   virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE);
   virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) ;


### PR DESCRIPTION
This PR adds 'add' functions to RooArgSet again, that were removed in 6.06/00.

### Problem

This pyROOT code

```python
import ROOT
set1 = ROOT.RooArgSet()
set2 = ROOT.RooArgSet()
set1.add(set2)
```

worked until 6.05/02 (included) and raises an exception since 6.06/00:

```shell
TypeError: bool RooArgSet::add(const RooAbsArg& var, bool silent = kFALSE) =>
    could not convert argument 1
```


### Fix

RooArgSet inherits from RooAbsCollection, so it should be possible to add a RootArgSet instance to an other RootArgSet instance via `add()`. This used to work in versions prior to 6.06/00. From [`RooArgSet.h in 6.05/02`](https://github.com/root-mirror/root/blob/v6-05-02/roofit/roofitcore/inc/RooArgSet.h#L90):

```cpp
class RooArgSet : public RooAbsCollection {
public:
    ...
    virtual Bool_t add(const RooAbsCollection& list, Bool_t silent=kFALSE) {...}
};
```

This was changed in commit 283f080, where e.g. the above `add` function was replaced by

```cpp
using RooAbsCollection::add;
```

However, this only seems to work when the *used* function is implemented in the base class' header or re-implemented by the inheriting class' which both is not the case. Therefore, I added the functions again to the RooArgSet header.

