### PR TITLE
Resolve tbb scheduler conflicts

### DIFF
--- a/core/thread/inc/ROOT/TThreadExecutor.hxx
+++ b/core/thread/inc/ROOT/TThreadExecutor.hxx
@@ -75,6 +75,9 @@ public:
   template<class T, class R> auto Reduce(const std::vector<T> &objs, R redfunc) -> decltype(redfunc(objs));
   using TExecutor<TThreadExecutor>::Reduce;
 
+  //Returns the number of threads set in the scheduler at call time.
+  static int GetPoolSize(){return fgPoolSize;}
+
 protected:
 
    template<class F, class R, class Cond = noReferenceCond<F>>


### PR DESCRIPTION
Both EnableEmplicitMT and TThreadExecutor implementations share the
same task scheduler and the number of threads it has been set to run on

This patch modifies TThreadExecutor so it:

* avoids the termination (from TThreadExecutor) of the scheduler
  initialized by EnableEmplicitMT.
* warns the user if she/he tries to change an already-set number of
  threads, as the scheduler will always take the value of its first
  initialization.