### PR TITLE
[tmva] WIP: DecisionTreeNode use static_cast instead of dynamic_cast

### DIFF
--- a/tmva/tmva/inc/TMVA/DecisionTree.h
+++ b/tmva/tmva/inc/TMVA/DecisionTree.h
@@ -99,7 +99,7 @@ namespace TMVA {
       virtual ~DecisionTree( void );
 
       // Retrieves the address of the root node
-      virtual DecisionTreeNode* GetRoot() const { return dynamic_cast<TMVA::DecisionTreeNode*>(fRoot); }
+      virtual DecisionTreeNode* GetRoot() const { return static_cast<TMVA::DecisionTreeNode*>(fRoot); }
       virtual DecisionTreeNode * CreateNode(UInt_t) const { return new DecisionTreeNode(); }
       virtual BinaryTree* CreateTree() const { return new DecisionTree(); }
       static  DecisionTree* CreateFromXML(void* node, UInt_t tmva_Version_Code = TMVA_VERSION_CODE);

--- a/tmva/tmva/inc/TMVA/DecisionTreeNode.h
+++ b/tmva/tmva/inc/TMVA/DecisionTreeNode.h
@@ -282,14 +282,14 @@ namespace TMVA {
       // get pointers to children, mother in the tree
 
       // return pointer to the left/right daughter or parent node
-      inline virtual DecisionTreeNode* GetLeft( )   const { return dynamic_cast<DecisionTreeNode*>(fLeft); }
-      inline virtual DecisionTreeNode* GetRight( )  const { return dynamic_cast<DecisionTreeNode*>(fRight); }
-      inline virtual DecisionTreeNode* GetParent( ) const { return dynamic_cast<DecisionTreeNode*>(fParent); }
+      inline virtual DecisionTreeNode* GetLeft( )   const { return static_cast<DecisionTreeNode*>(fLeft); }
+      inline virtual DecisionTreeNode* GetRight( )  const { return static_cast<DecisionTreeNode*>(fRight); }
+      inline virtual DecisionTreeNode* GetParent( ) const { return static_cast<DecisionTreeNode*>(fParent); }
 
       // set pointer to the left/right daughter and parent node
-      inline virtual void SetLeft  (Node* l) { fLeft   = dynamic_cast<DecisionTreeNode*>(l);} 
-      inline virtual void SetRight (Node* r) { fRight  = dynamic_cast<DecisionTreeNode*>(r);} 
-      inline virtual void SetParent(Node* p) { fParent = dynamic_cast<DecisionTreeNode*>(p);} 
+      inline virtual void SetLeft  (Node* l) { fLeft   = static_cast<DecisionTreeNode*>(l);} 
+      inline virtual void SetRight (Node* r) { fRight  = static_cast<DecisionTreeNode*>(r);} 
+      inline virtual void SetParent(Node* p) { fParent = static_cast<DecisionTreeNode*>(p);} 
 
 
 

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -562,9 +562,9 @@ void TMVA::DecisionTree::FillEvent( const TMVA::Event & event,
   
    if (node->GetNodeType() == 0) { //intermediate node --> go down
       if (node->GoesRight(event))
-         this->FillEvent(event,dynamic_cast<TMVA::DecisionTreeNode*>(node->GetRight())) ;
+         this->FillEvent(event,static_cast<TMVA::DecisionTreeNode*>(node->GetRight())) ;
       else
-         this->FillEvent(event,dynamic_cast<TMVA::DecisionTreeNode*>(node->GetLeft())) ;
+         this->FillEvent(event,static_cast<TMVA::DecisionTreeNode*>(node->GetLeft())) ;
    }
   
   


### PR DESCRIPTION
Following discussions in TMVA developers meetings.

Callgrind reports large (factor 2ish) reduction of CPU cycles for BDT evaluation.

TODO: careful review if mixed trees can actually occur!

Credits to F. Lemaitre for the suggestion to remove the dynamic_casts in this way (as opposed to the implementation I was working on).

PS: filed PR against patches v6-08-00-patches to keep the diff readable for now.