### PR TITLE
libAfterImage: apply changes for giflib-5 and other minor updates

### DIFF
--- a/graf2d/asimage/src/libAfterImage/Makefile.in
+++ b/graf2d/asimage/src/libAfterImage/Makefile.in
@@ -83,7 +83,7 @@ CP		= @CP@
 MV		= @MV@
 RM		= @RM@
 RMF		= @RM@ -f
-MKDIR		= @MKDIR@
+MKDIR		= @MKDIR@ -p
 FIND		= @FIND@
 XARGS		= @XARGS@
 LDCONFIG	= @LDCONFIG@
@@ -145,20 +145,6 @@ install.static: 	mkdir
 		@(if [ -d $(LIBDIR) ] && [ -w $(LIBDIR) ]; then \
 		    echo "$(INSTALL_LIB) $(LIB_STATIC) $(LIBDIR)"; \
 		    $(INSTALL_LIB) $(LIB_STATIC) $(LIBDIR); \
-		    if [ `uname` = "Linux" ]; then \
-			if test $(LIBDIR) = "/lib" || test $(LIBDIR) = "/usr/lib"; then \
-		    	    echo "" > /dev/null; \
-			elif grep -q $(LIBDIR) /etc/ld.so.conf > /dev/null 2>&1; then \
-		    	    echo "" > /dev/null; \
-			else \
-		    	    echo "Unable to find $(LIBDIR) in ld.so.conf. In order to use "; \
-		    	    echo "$(LIB_STATIC), you may need to add it or set LD_LIBRARY_PATH."; \
-			fi; \
-			if test -w /etc; then \
-			    echo "$(LDCONFIG)"; \
-			    $(LDCONFIG); \
-			fi; \
-		    fi ;\
 		fi \
 		)
 
@@ -171,18 +157,6 @@ install.dyn:	mkdir
 		$(RM) -f $(LIBDIR)/$(LIB_SHARED).$(LIBVERMAJOR) $(LIBDIR)/$(LIB_SHARED); \
 		$(LN_S) -f $(LIB_SHARED).$(LIBVER) $(LIBDIR)/$(LIB_SHARED).$(LIBVERMAJOR); \
 		$(LN_S) -f $(LIB_SHARED).$(LIBVERMAJOR) $(LIBDIR)/$(LIB_SHARED); \
-		if test `uname` = "Linux"; then \
-		   if test $(LIBDIR) = "/lib" || test $(LIBDIR) = "/usr/lib"; then \
-		     echo "" > /dev/null; \
-		   elif grep -q $(LIBDIR) /etc/ld.so.conf > /dev/null 2>&1; then \
-		     echo "" > /dev/null; \
-		   else \
-		     echo "Unable to find $(LIBDIR) in ld.so.conf. In order to use "; \
-		     echo "$(LIB_SHARED), you may need to add it or set LD_LIBRARY_PATH."; \
-		   fi; \
-		   echo "$(LDCONFIG)"; \
-		   $(LDCONFIG); \
-		 fi \
 		)
 
 install.cyg:	mkdir
@@ -397,8 +371,8 @@ $(LIB_SHARED).$(LIBVERMAJOR): $(LIB_SHARED).$(LIBVER)
 	$(LN_S) -f $(LIB_SHARED).$(LIBVER) $(LIB_SHARED).$(LIBVERMAJOR)
 
 $(LIB_SHARED).$(LIBVER): $(LIB_OBJS) $(LIB_INCS) config.h
-	$(CC) -shared -Wl,-soname,$(LIB_SHARED).$(LIBVERMAJOR) -o $(LIB_SHARED).$(LIBVER) \
-	 $(LIB_OBJS)
+	$(CC) -shared $(USER_LD_FLAGS) -Wl,-soname,$(LIB_SHARED).$(LIBVERMAJOR) -o $(LIB_SHARED).$(LIBVER) \
+	 $(LIB_OBJS) $(LIBRARIES)
 
 install.man:
 		@if [ -d doc/man ] ; then \

--- a/graf2d/asimage/src/libAfterImage/afterimage-config.in
+++ b/graf2d/asimage/src/libAfterImage/afterimage-config.in
@@ -115,11 +115,7 @@ if test "$echo_libs" = "yes" ; then
         	libs="-lAfterBase $libs"
  	fi
  	libs="-lAfterImage $libs" 
-	if test "@libdir@" != "/usr/lib" ; then
-  		echo -L@libdir@ $libs
- 	else
-  		echo $libs
- 	fi
+        echo $libs
  else
         echo $libs
  fi

--- a/graf2d/asimage/src/libAfterImage/configure.in
+++ b/graf2d/asimage/src/libAfterImage/configure.in
@@ -60,12 +60,9 @@ dnl# AC_ARG_WITH(builtin_xpm,    [  --with-builtin-xpm       use builtin XPM par
 dnl# AC_ARG_WITH(xpm_includes,   [  --with-xpm-includes=DIR  use libXpm includes in DIR( when builtin XPM handling is disabled )], xpm_includes="$withval", xpm_includes=no)
 
 dnl# standard libgif/ungif should not be used and considered obsolete!
-dnl# AC_ARG_WITH(ungif,		    [  --with-ungif             support Uncompressed GIF image format using libungif [no]],with_ungif="$withval",with_ungif=no)
-dnl# AC_ARG_WITH(gif,		    [  --with-gif               support GIF image format using libgif   [no]],with_gif="$withval",with_gif=no)
-dnl# AC_ARG_WITH(gif_includes,   [  --with-gif-includes=DIR  use GIF includes in DIR], gif_includes="$withval", gif_includes=no)
-with_ungif=no
-with_gif=no
-with_gif_includes=no
+AC_ARG_WITH(ungif,		    [  --with-ungif             support Uncompressed GIF image format using libungif [no]],with_ungif="$withval",with_ungif=no)
+AC_ARG_WITH(gif,		    [  --with-gif               support GIF image format using libgif   [no]],with_gif="$withval",with_gif=no)
+AC_ARG_WITH(gif_includes,   [  --with-gif-includes=DIR  use GIF includes in DIR], gif_includes="$withval", gif_includes=no)
 AC_ARG_WITH(builtin_gif,    [  --with-builtin-gif               support Uncompressed GIF image format using builtin libgif [yes]],with_builtin_gif="$withval",with_builtin_gif=yes)
 
 

--- a/graf2d/asimage/src/libAfterImage/ungif.h
+++ b/graf2d/asimage/src/libAfterImage/ungif.h
@@ -7,11 +7,29 @@
 extern "C" {
 #endif
 
+#if ((GIFLIB_MAJOR==4) && (GIFLIB_MINOR>=2)) 
+static inline void PrintGifError(void) {
+    fprintf(stderr, "%s\n", GifErrorString());
+}
+#elif (GIFLIB_MAJOR>=5)
+static inline void PrintGifError(int code) {
+    fprintf(stderr, "%s\n", GifErrorString(code));
+}
+#endif
+
+#if (GIFLIB_MAJOR>=5)
+#ifdef __GNUC__
+#define ASIM_PrintGifError(code) do{ fprintf( stderr, "%s():%d:<%s> ",__FUNCTION__, __LINE__, path?path:"null" ); PrintGifError(code); }while(0)
+#else
+#define ASIM_PrintGifError(code) do{ PrintGifError(code); }while(0)
+#endif
+#else // (GIFLIB_MAJOR>=5)
 #ifdef __GNUC__
 #define ASIM_PrintGifError() do{ fprintf( stderr, "%s():%d:<%s> ",__FUNCTION__, __LINE__, path?path:"null" ); PrintGifError(); }while(0)
 #else
 #define ASIM_PrintGifError() do{ PrintGifError(); }while(0)
 #endif
+#endif // (GIFLIB_MAJOR>=5)
 
 #define GIF_GCE_DELAY_BYTE_LOW	1
 #define GIF_GCE_DELAY_BYTE_HIGH	2
@@ -24,7 +42,11 @@ void free_gif_saved_images( SavedImage *images, int count );
 
 
 int fread_gif( GifFileType *gif, GifByteType* buf, int len );
+#if (GIFLIB_MAJOR>=5)
+GifFileType* open_gif_read( FILE *in_stream, int *errcode );
+#else
 GifFileType* open_gif_read( FILE *in_stream );
+#endif
 
 int get_gif_image_desc( GifFileType *gif, SavedImage *im );
 


### PR DESCRIPTION
Port patch by @bircoph to support giflib-5, as well as some minor build system updates. Since the bundled version of libAfterImage in ROOT got some updates of its own, an effort was made to
keep those changes intact. For more information, please refer to the bug report at https://bugs.gentoo.org/571654. Fixes [ROOT-7904](https://sft.its.cern.ch/jira/browse/ROOT-7904).