### PR TITLE
[TDF] Minor improvements

### DIFF
--- a/tree/treeplayer/src/TDataFrame.cxx
+++ b/tree/treeplayer/src/TDataFrame.cxx
@@ -195,7 +195,7 @@ const TDataFrameBranchBase &TDataFrameImpl::GetBookedBranch(const std::string &n
    return *fBookedBranches.find(name)->second.get();
 }
 
-void *TDataFrameImpl::GetTmpBranchValue(const std::string &branch, unsigned int slot, int entry)
+void *TDataFrameImpl::GetTmpBranchValue(const std::string &branch, unsigned int slot, Long64_t entry)
 {
    return fBookedBranches.at(branch)->GetValue(slot, entry);
 }


### PR DESCRIPTION
Fix a few minor things and pave the way to integrate cutflow reports in TDataFrame

* TDFAction ctor can take a shared_ptr instead of a weak_ptr: TDFAction
  can safely assume that the previous node in the chain still exists when it is
  being constructed
* fPrevData is now a reference instead of a raw pointer in all classes:
  a reference better indicates that we always expect fPrevData to be a valid
  node of the chain. In fact, the only case when this condition might not be
  met is when the TDataFrameImpl object goes out-of-scope before other nodes
  of the chain; we detect this case and throw before trying to access
  invalid fPrevData pointers/references.
* use `Long64_t` instead of `int` for all entry variables