### PR TITLE
[TDF] template TDFInterface on virtual base classes only

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDataFrame.hxx
+++ b/tree/treeplayer/inc/ROOT/TDataFrame.hxx
@@ -920,6 +920,9 @@ public:
    TDataFrame(TTree &tree, const BranchNames &defaultBranches = {});
 };
 
+extern template class TDataFrameInterface<ROOT::Detail::TDataFrameFilterBase>;
+extern template class TDataFrameInterface<ROOT::Detail::TDataFrameBranchBase>;
+
 } // end NS Experimental
 
 namespace Detail {

--- a/tree/treeplayer/src/TDataFrame.cxx
+++ b/tree/treeplayer/src/TDataFrame.cxx
@@ -635,6 +635,8 @@ void TDataFrameImpl::Report() const {
 namespace Experimental {
 
 template class TDataFrameInterface<ROOT::Detail::TDataFrameImpl>;
+template class TDataFrameInterface<ROOT::Detail::TDataFrameFilterBase>;
+template class TDataFrameInterface<ROOT::Detail::TDataFrameBranchBase>;
 
 } // end NS Experimental
 


### PR DESCRIPTION
This reduces the different specializations of TDFInterface that have to be instantiated to three.