### PR TITLE
Missing header

### DIFF
--- a/test/stressEntryList.cxx
+++ b/test/stressEntryList.cxx
@@ -38,6 +38,7 @@
 #include <map>
 #include <list>
 #include <array>
+#include <functional>
 #include <stdlib.h>
 #include "TApplication.h"
 #include "TEntryList.h"


### PR DESCRIPTION
    /builddir/build/BUILD/root-6.08.04/test/stressEntryList.cxx:616:42: error: 'function' is not a member of 'std'
        using fcnCharPtrPair = std::pair<std::function<bool()>,const char*>;
