### PR TITLE
[TDF] Move callables instead of copying them whenever possible

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFTraitsUtils.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFTraitsUtils.hxx
@@ -76,7 +76,7 @@ struct TRemoveFirst<TTypeList<T, Args...>> {
 
 // return wrapper around f that prepends an `unsigned int slot` parameter
 template <typename R, typename F, typename... Args>
-std::function<R(unsigned int, Args...)> AddSlotParameter(F f, TTypeList<Args...>)
+std::function<R(unsigned int, Args...)> AddSlotParameter(F&& f, TTypeList<Args...>)
 {
    return [f](unsigned int, Args... a) -> R { return f(a...); };
 }


### PR DESCRIPTION
This is an internal change. The user interface remains unchanged, as we probably want to copy callables passed to `TDataFrame` by value in all cases.