### PR TITLE
[TDF] add Reduce action

### DIFF
--- a/tree/treeplayer/inc/ROOT/TDFOperations.hxx
+++ b/tree/treeplayer/inc/ROOT/TDFOperations.hxx
@@ -292,6 +292,33 @@ public:
    }
 };
 
+template<typename F, typename T>
+class ReduceOperation {
+   F fReduceFun;
+   T* fReduceRes;
+   std::vector<T> fReduceObjs;
+public:
+   ReduceOperation(F&& f, T* reduceRes, unsigned int nSlots) : fReduceFun(f),
+      fReduceRes(reduceRes), fReduceObjs(nSlots, *reduceRes)
+   { }
+
+   void Exec(const T& value, unsigned int slot)
+   {
+      fReduceObjs[slot] = fReduceFun(fReduceObjs[slot], value);
+   }
+
+   void Finalize()
+   {
+      for (auto& t : fReduceObjs)
+         *fReduceRes = fReduceFun(*fReduceRes, t);
+   }
+
+   ~ReduceOperation()
+   {
+      Finalize();
+   }
+};
+
 class MinOperation {
    double *fResultMin;
    std::vector<double> fMins;


### PR DESCRIPTION
example usage:

```c++
ROOT::Experimental::TDataFrame d("reduceTree", &f, {"i"});
auto r = d.Reduce([](int a, int b) { return a + b; }, {"i"}); // sum all branch values
auto rDefBranch = d.Filter([]() { return true; })
                   .Reduce([](int a, int b) { return a*b; }, {}, 1); // multiply all branch values

```

A PR with a unit test has been submitted to the roottest repo.