### PR TITLE
Fix for test suite on Fedora 26 i686

### DIFF
--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -1210,7 +1210,9 @@ void TMath::Quantiles(Int_t n, Int_t nprob, Double_t *x, Double_t *quantiles, Do
          else
             nppm = n*prob[i]; // use m = 0
 
-         j = TMath::FloorNint(nppm);
+         // be careful with machine precision
+         double eps = 4 * TMath::Limits<Double_t>::Epsilon();
+         j = TMath::FloorNint(nppm + eps);
 
          // LM : fix for numerical problems if nppm is actually equal to j, but results different for numerical error
          // g in the paper is nppm -j


### PR DESCRIPTION
      7/602 Test  #11: mathcore-testSampleQuantiles ...............................***Failed    2.24 sec
    Test ordered data ....
    Testing for type 7 :		.............	 OK !
    Testing for type 1 :		.............	 OK !
    Testing for type 2 :		....  Failed for prob = 0.3 -  R gives 0.85 TMath gives 0.7
    ..  Failed for prob = 0.6 -  R gives 1.65 TMath gives 1.5
      Failed for prob = 0.7 -  R gives 1.9 TMath gives 1.8
    ....
    Test Failed for type 2
    Testing for type 3 :		.............	 OK !
    Testing for type 4 :		.............	 OK !
    Testing for type 5 :		.............	 OK !
    Testing for type 6 :		.............	 OK !
    Testing for type 7 :		.............	 OK !
    Testing for type 8 :		.............	 OK !
    Testing for type 9 :		.............	 OK !
    Test  data in random order....
    Testing for type 7 :		.............	 OK !
    Testing for type 1 :		.............	 OK !
    Testing for type 2 :		....  Failed for prob = 0.3 -  R gives 0.85 TMath gives 0.7
    ..  Failed for prob = 0.6 -  R gives 1.65 TMath gives 1.5
      Failed for prob = 0.7 -  R gives 1.9 TMath gives 1.8
    ....
    Test Failed for type 2
    Testing for type 3 :		.............	 OK !
    Testing for type 4 :		.............	 OK !
    Testing for type 5 :		.............	 OK !
    Testing for type 6 :		.............	 OK !
    Testing for type 7 :		.............	 OK !
    Testing for type 8 :		.............	 OK !
    Testing for type 9 :		.............	 OK !
    Test sample quantiles FAILED 
    CMake Error at /builddir/build/BUILD/root-6.08.04/cmake/modules/RootTestDriver.cmake:196 (message):
      error code: 255


The PR implements the same check for type < 4 that is done later in the else clause for type >= 4. So this treats all types the same and the test failure goes away.
