### PR TITLE
Attempt to solve race conditions on roostats tests

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -270,6 +270,19 @@ foreach(tname  ModelInspector OneSidedFrequentistUpperLimitWithBands StandardBay
   set(roostats-${tname}-depends tutorial-histfactory-makeExample)
 endforeach()
 
+#--ensure that roostats tests accesses test file sequentially
+set(roostats-ModelInspector-depends "${roostats-ModelInspector-depends} roostats-OneSidedFrequentistUpperLimitWithBands")
+set(roostats-OneSidedFrequentistUpperLimitWithBands-depends "${roostats-OneSidedFrequentistUpperLimitWithBands-depends} roostats-StandardBayesianMCMCDemo")
+set(roostats-StandardBayesianMCMCDemo-depends "${roostats-StandardBayesianMCMCDemo-depends} roostats-StandardBayesianNumericalDemo")
+set(roostats-StandardBayesianNumericalDemo-depends "${roostats-StandardBayesianNumericalDemo-depends} roostats-StandardFeldmanCousinsDemo")
+set(roostats-StandardFeldmanCousinsDemo-depends "${roostats-StandardFeldmanCousinsDemo-depends} roostats-StandardHistFactoryPlotsWithCategories")
+set(roostats-StandardHistFactoryPlotsWithCategories-depends "${roostats-StandardHistFactoryPlotsWithCategories-depends} roostats-StandardHypoTestDemo")
+set(roostats-StandardHypoTestDemo-depends "${roostats-StandardHypoTestDemo-depends} roostats-StandardHypoTestInvDemo")
+set(roostats-StandardHypoTestInvDemo-depends "${roostats-StandardHypoTestInvDemo-depends} roostats-StandardProfileInspectorDemo")
+set(roostats-StandardProfileInspectorDemo-depends "${roostats-StandardProfileInspectorDemo-depends} roostats-StandardProfileLikelihoodDemo")
+set(roostats-StandardProfileLikelihoodDemo-depends "${roostats-StandardProfileLikelihoodDemo-depends} roostats-StandardTestStatDistributionDemo")
+set(roostats-StandardTestStatDistributionDemo-depends "${roostats-StandardTestStatDistributionDemo-depends} roostats-TwoSidedFrequentistUpperLimitWithBands")
+
 #--dependency for TMVA tutorials
 set (tmva-TMVAClassificationApplication-depends tutorial-tmva-TMVAClassification)
 set (tmva-TMVAClassificationCategory-depends tutorial-tmva-TMVAClassification)


### PR DESCRIPTION
Some of the tests in `tutorials/roostats/` uses the file `example_combined_GaussExample_model.root`. If this file does not exist, one of the tests will create it. As these are executed in parallel, there is a chance of race condition and one of the tests might fail, as seen in this build: http://cdash.cern.ch/testDetails.php?test=22401472&build=324697
This PR attempts to fix this by executing all tests sequentially that uses the file `example_combined_GaussExample_model.root`