### PR TITLE
Give TMultiGraph and THStack an __iter__ method

### DIFF
--- a/hist/hist/inc/THStack.h
+++ b/hist/hist/inc/THStack.h
@@ -77,7 +77,6 @@ public:
    virtual void     SetMaximum(Double_t maximum=-1111); // *MENU*
    virtual void     SetMinimum(Double_t minimum=-1111); // *MENU*
 
-
    ClassDef(THStack,2)  //A collection of histograms
 };
 

--- a/hist/hist/inc/THStack.h
+++ b/hist/hist/inc/THStack.h
@@ -60,6 +60,8 @@ public:
    TList           *GetHists()  const { return fHists; }
    Int_t            GetNhists() const;
    TObjArray       *GetStack();
+   TIter            begin() const;
+   TIter            end() const { return TIter::End(); }
    virtual Double_t GetMaximum(Option_t *option="");
    virtual Double_t GetMinimum(Option_t *option="");
    TAxis           *GetXaxis() const;
@@ -74,6 +76,7 @@ public:
    virtual void     SetHistogram(TH1 *h) {fHistogram = h;}
    virtual void     SetMaximum(Double_t maximum=-1111); // *MENU*
    virtual void     SetMinimum(Double_t minimum=-1111); // *MENU*
+
 
    ClassDef(THStack,2)  //A collection of histograms
 };

--- a/hist/hist/inc/THStack.h
+++ b/hist/hist/inc/THStack.h
@@ -58,10 +58,10 @@ public:
    virtual void     Draw(Option_t *chopt="");
    TH1             *GetHistogram() const;
    TList           *GetHists()  const { return fHists; }
-   Int_t            GetNhists() const;
-   TObjArray       *GetStack();
    TIter            begin() const;
    TIter            end() const { return TIter::End(); }
+   Int_t            GetNhists() const;
+   TObjArray       *GetStack();
    virtual Double_t GetMaximum(Option_t *option="");
    virtual Double_t GetMinimum(Option_t *option="");
    TAxis           *GetXaxis() const;

--- a/hist/hist/inc/TMultiGraph.h
+++ b/hist/hist/inc/TMultiGraph.h
@@ -67,6 +67,8 @@ public:
    TH1F             *GetHistogram() const;
    TF1              *GetFunction(const char *name) const;
    TList            *GetListOfGraphs() const { return fGraphs; }
+   TIter             begin() const;
+   TIter             end() const { return TIter::End(); }
    TList            *GetListOfFunctions();  // non const method (create list if empty)
    const TList      *GetListOfFunctions() const { return fFunctions; }
    TAxis            *GetXaxis() const;

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -1045,3 +1045,8 @@ void THStack::SetMinimum(Double_t minimum)
    fMinimum = minimum;
    if (fHistogram) fHistogram->SetMinimum(minimum);
 }
+
+TIter THStack::begin() const
+{
+  return fHists->begin();
+}

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -1046,6 +1046,9 @@ void THStack::SetMinimum(Double_t minimum)
    if (fHistogram) fHistogram->SetMinimum(minimum);
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get iterator over itnernal hists list.
 TIter THStack::begin() const
 {
   return fHists->begin();

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -1051,5 +1051,5 @@ void THStack::SetMinimum(Double_t minimum)
 /// Get iterator over itnernal hists list.
 TIter THStack::begin() const
 {
-  return fHists->begin();
+  return TIter(fHists);
 }

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -1048,7 +1048,7 @@ void THStack::SetMinimum(Double_t minimum)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get iterator over itnernal hists list.
+/// Get iterator over internal hists list.
 TIter THStack::begin() const
 {
   return TIter(fHists);

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1474,6 +1474,8 @@ void TMultiGraph::SetMinimum(Double_t minimum)
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Get iterator over internal graphs list.
 TIter TMultiGraph::begin() const
 {
   return fGraphs->begin();

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1478,5 +1478,5 @@ void TMultiGraph::SetMinimum(Double_t minimum)
 /// Get iterator over internal graphs list.
 TIter TMultiGraph::begin() const
 {
-  return fGraphs->begin();
+  return TIter(fGraphs);
 }

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1472,3 +1472,9 @@ void TMultiGraph::SetMinimum(Double_t minimum)
    fMinimum = minimum;
    if (fHistogram) fHistogram->SetMinimum(minimum);
 }
+
+
+TIter TMultiGraph::begin() const
+{
+  return fGraphs->begin();
+}


### PR DESCRIPTION
In order for the Python bindings to pick up that a stack and a multi graph are iterable, they need the `begin` and `end` methods implemented. This PR does just that. With these changes one can natively iterate over the histograms/graphs in those objects:

```{python}
import ROOT

h1 = ROOT.TH1D("h1", "h1", 100, 0, 100)
h2 = ROOT.TH1D("h2", "h2", 100, 0, 100)
stack = ROOT.THStack()
stack.Add(h1)
stack.Add(h2)
for hist in stack:
    print hist.GetTitle()

g1 = ROOT.TGraph()
g2 = ROOT.TGraph()
mg = ROOT.TMultiGraph()
mg.Add(g1)
mg.Add(g2)
print list(mg)
```

One debatable choice is whether `end` should directly return `TIter::End()` or return `fHists->end()`.The former is directly copied from `TList::end` but could potentially change(?).