### PR TITLE
Ignore drawing on batch mode for mlpRegression tutorial

### DIFF
--- a/tutorials/mlp/mlpRegression.C
+++ b/tutorials/mlp/mlpRegression.C
@@ -86,5 +86,8 @@ void mlpRegression() {
    TGraph2D* g2Extrapolate=new TGraph2D("ANN extrapolation",
                                         "ANN extrapolation, ANN output - truth",
                                         225, vx, vy, delta);
-   g2Extrapolate->Draw("TRI2");
+
+   if (!gROOT->IsBatch()) {
+      g2Extrapolate->Draw("TRI2");
+   }
 }


### PR DESCRIPTION
When it tries to draw the last diagram, it freezes on some builds. Instead, ignore drawing if we are in batch mode.

This PR fixes this failing test:
http://cdash.cern.ch/testDetails.php?test=22567643&build=326532